### PR TITLE
add openshift permissions for compliance scanning

### DIFF
--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -135,13 +135,25 @@ system:
         - apiGroups: [""]
           resources: ["nodes"]
           verbs: ["get", "list", "patch"]
-    openshift-cluster-info:
+    openshift-permissions:
       rules:
         - apiGroups: ["config.openshift.io"]
-          resources: ["clusterversions"]
+          resources: ["clusterversions", "apiservers", "authentications", "clusteroperators", "oauths"]
           verbs: ["get", "list", "watch"]
         - apiGroups: ["aro.openshift.io"]
           resources: ["clusters"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["operator.openshift.io"]
+          resources: ["kubeapiservers", "openshiftapiservers", "ingresscontrollers", "networks"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["image.openshift.io"]
+          resources: ["images", "imagestreams"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["route.openshift.io"]
+          resources: ["routes"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["security.openshift.io"]
+          resources: ["securitycontextconstraints"]
           verbs: ["get", "list", "watch"]
     otel:
       rules:


### PR DESCRIPTION
**Description**
This change introduces a new set of OpenShift permissions specifically tailored for compliance scanning. The openshift-permissions ruleset grants read-only access (get, list, watch) to a range of OpenShift resources across several OpenShift API groups. These permissions are intended to enable compliance scanning tools to gather the necessary cluster state and configuration information without granting write or administrative privileges.

**Motivation and Context**
Compliance scanning tools require access to various OpenShift resources to assess cluster configuration, security posture, and operational state. By defining a dedicated set of read-only permissions, we ensure that these tools can function effectively while adhering to the principle of least privilege. This helps minimize security risks and supports regulatory compliance requirements.
This change addresses internal security and compliance initiatives and is a foundational step for enabling automated compliance checks in OpenShift environments.

**How Has This Been Tested?**
The new permissions were applied to a test service account within a non-production OpenShift cluster. Automated compliance scanning tools were run to verify that all required resources could be accessed and that no permission errors occurred. Cluster audit logs were reviewed to confirm that only the intended resources and verbs were used. No regressions or unintended access were observed in other areas of the cluster.

**Types of changes**
New feature (non-breaking change which adds functionality)