### PR TITLE
fix: add config.openshift.io/infrastructures object to permissions

### DIFF
--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.8
+version: 1.0.9
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -138,7 +138,7 @@ system:
     openshift-permissions:
       rules:
         - apiGroups: ["config.openshift.io"]
-          resources: ["clusterversions", "apiservers", "authentications", "clusteroperators", "oauths"]
+          resources: ["clusterversions", "apiservers", "authentications", "clusteroperators", "oauths", "infrastructures"]
           verbs: ["get", "list", "watch"]
         - apiGroups: ["aro.openshift.io"]
           resources: ["clusters"]


### PR DESCRIPTION
## Description

add openshift infrastructure object to permissions model

## Motivation and Context

To distinguish between ARO/ROSA flavors of openshift, when resolving the cluster unique identifier this object needs to be queried.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
