### PR TITLE
Feat: Update delete Job image and the secrets konnector-docker-secret & distribution-id

### DIFF
--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.20
+version: 1.0.21
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/templates/batch.yaml
+++ b/charts/konnector/templates/batch.yaml
@@ -65,9 +65,12 @@ spec:
             capabilities:
               drop:
               - ALL
-      {{- if and .Values.deleteJob.reusePullSecret .Values.dockerPullSecret }}
+      {{- if .Values.deleteJob.secret.reuse }}
       imagePullSecrets:
       - name: {{ .Values.system.secrets.dockerSecret.name }}
+      {{- else if .Values.deleteJob.secret.name }}
+      imagePullSecrets:
+      - name: {{ .Values.deleteJob.secret.name }}
       {{- end }}
      {{- with .Values.system.apps.tolerations }}
       tolerations:

--- a/charts/konnector/templates/batch.yaml
+++ b/charts/konnector/templates/batch.yaml
@@ -36,9 +36,12 @@ spec:
     spec:
       serviceAccountName: {{ .Values.system.serviceAccount.name }}
       restartPolicy: "Never"
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: helm-uninstall
-          image: alpine/helm:3.17.2
+          image: "{{ .Values.deleteJob.image.repository }}/{{ .Values.deleteJob.image.name }}{{- if .Values.deleteJob.image.tag }}:{{ .Values.deleteJob.image.tag }}{{- end }}{{- if .Values.deleteJob.image.digest }}@{{ .Values.deleteJob.image.digest }}{{- end }}"
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -56,6 +59,16 @@ spec:
                   echo -e "\033[33m{{ .Values.system.K8sManager.ReleaseName }} not found, skipping uninstall.\033[0m";
                   exit 0
                 fi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - ALL
+      {{- if and .Values.deleteJob.reusePullSecret .Values.dockerPullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.system.secrets.dockerSecret.name }}
+      {{- end }}
      {{- with .Values.system.apps.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/konnector/templates/secret.yaml
+++ b/charts/konnector/templates/secret.yaml
@@ -12,6 +12,20 @@ stringData:
   sosToken: "--set-by-konnnector-at-runtime--"
   chapi: "--set-by-konnnector-at-runtime--"
 ---
+{{- if .Values.deleteJob.secret.create }}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{ .Values.deleteJob.secret.name }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+data:
+  .dockerconfigjson: {{ .Values.deleteJob.secret.dockerPullSecret | default ( "{}" | b64enc ) }}
+{{- end }}
+---
+{{- if .Values.createPullSecret }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
@@ -22,7 +36,9 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 data:
   .dockerconfigjson: {{ .Values.dockerPullSecret | default ( "{}" | b64enc ) }}
+{{- end }}
 ---
+{{- if .Values.distribution.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -33,6 +49,7 @@ metadata:
 type: Opaque
 stringData:
   distribution-id: {{ .Values.distribution.id | required "The distribution.id value is required!" | quote }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -19,10 +19,12 @@ namespace:
   name: pan  # Kubernetes namespace where resources will be deployed
 
 dockerPullSecret: ""  # Secret for pulling images from a private registry
+createPullSecret: true  # Create secret to pull images. Set to false if the secret is being created from external source
 
 distribution:
   id: "default-distribution-id"  # Retrieve distribution ID from Palo Alto Networks systems during installation
   url: "https://distributions.traps.paloaltonetworks.com"  # Retrieve distribution URL from Palo Alto Networks systems during installation
+  createSecret: true  # Create the secret corresponding to the distribuition id. Set to false if the secret is being created from external source 
 
 optionalValues:
   CLUSTER_URI: ""    # Cluster URI should be set when metadata service is not reachable from the cluster
@@ -39,8 +41,11 @@ deleteJob:  # These values correspond to a Job used for deleting resources
     name: "alpine/helm"     # Name of the image to be used
     tag: "3.17.2"           # Tag for the image
     digest: ""              # Image digest (optional)
-  reusePullSecret: false    # Reuse the dockerPullSecret parameter to pull such image
-
+  secret:
+    reuse: false            # Reuse the pull secret from the KSPM Connector
+    create: false           # Create Secret to pull the deleteJob image. Set to true if not being exported from external vault
+    dockerPullSecret:       # Value of the pull secret if create is set to true and reuse to false
+    name:                   # Name of the secret to  pull the deleteJob
 
 # ==========================
 # ### System Section ###

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -32,6 +32,16 @@ optionalValues:
 proxyValues:
   httpProxy: ""  # Optional proxy URL for external network access
   noProxy: "kubernetes,kubernetes.default.svc,.svc,.cluster.local"  # List of addresses/domains that should bypass the proxy
+
+deleteJob:  # These values correspond to a Job used for deleting resources
+  image:
+    repository: "docker.io" # Repository where the image of is stored
+    name: "alpine/helm"     # Name of the image to be used
+    tag: "3.17.2"           # Tag for the image
+    digest: ""              # Image digest (optional)
+  reusePullSecret: false    # Reuse the dockerPullSecret parameter to pull such image
+
+
 # ==========================
 # ### System Section ###
 # ==========================

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -24,7 +24,7 @@ createPullSecret: true  # Create secret to pull images. Set to false if the secr
 distribution:
   id: "default-distribution-id"  # Retrieve distribution ID from Palo Alto Networks systems during installation
   url: "https://distributions.traps.paloaltonetworks.com"  # Retrieve distribution URL from Palo Alto Networks systems during installation
-  createSecret: true  # Create the secret corresponding to the distribuition id. Set to false if the secret is being created from external source 
+  createSecret: true  # Create the secret corresponding to the distribuition id. Set to false if the secret is being created from external source
 
 optionalValues:
   CLUSTER_URI: ""    # Cluster URI should be set when metadata service is not reachable from the cluster
@@ -37,15 +37,15 @@ proxyValues:
 
 deleteJob:  # These values correspond to a Job used for deleting resources
   image:
-    repository: "docker.io" # Repository where the image of is stored
-    name: "alpine/helm"     # Name of the image to be used
-    tag: "3.17.2"           # Tag for the image
-    digest: ""              # Image digest (optional)
+    repository: "docker.io"  # Repository where the image of is stored
+    name: "alpine/helm"  # Name of the image to be used
+    tag: "3.17.2"  # Tag for the image
+    digest: ""  # Image digest (optional)
   secret:
-    reuse: false            # Reuse the pull secret from the KSPM Connector
-    create: false           # Create Secret to pull the deleteJob image. Set to true if not being exported from external vault
-    dockerPullSecret:       # Value of the pull secret if create is set to true and reuse to false
-    name:                   # Name of the secret to  pull the deleteJob
+    reuse: false  # Reuse the pull secret from the KSPM Connector
+    create: false  # Create Secret to pull the deleteJob image. Set to true if not being exported from external vault
+    dockerPullSecret: ""  # Value of the pull secret if create is set to true and reuse to false
+    name: ""  # Name of the secret to  pull the deleteJob
 
 # ==========================
 # ### System Section ###


### PR DESCRIPTION
## Description
I've added the following features:
- The capability to use a private image for the delete Job of the chart k8s-connector-release
- Make optional the creation of secrets of konnector-docker-secret and distribution-id

## Motivation and Context

Since currently the Job for deleting the k8s-connector-release helm chart uses a public image, due to compliance requirements, I've added the capacity to use its own image stored in private registry by adding the following values:
```yaml
deleteJob:  # These values correspond to a Job used for deleting resources
  image:
    repository: "docker.io" # Repository where the image of is stored
    name: "alpine/helm"  # Name of the image to be used
    tag: "3.17.2"   # Tag for the image
    digest: ""        # Image digest (optional)
  secret:
    reuse: false  # Reuse the pull secret from the KSPM Connector
    create: false  # Create Secret to pull the deleteJob image. Set to true if not being exported from external vault
    dockerPullSecret:  # Value of the pull secret if create is set to true and reuse to false
    name:  # Name of the secret to  pull the deleteJob
```
As noticed this by default still uses the public image `alpine/helm:3.17.2`

Additionally, since for security purposes, some customers require to use a vault to store the secrets, therefore I've made the creation of the secrets konnector-docker-secret and distribution-id optional so this values can be retrieved from external sources, by introducing the following values:
```yaml
createPullSecret: true  # Create secret to pull images. Set to false if the secret is being created from external source

distribution:
  createSecret: true  # Create the secret corresponding to the distribuition id. Set to false if the secret is being created from external source 
```

## How Has This Been Tested?
It has been tested using EKS and Jfrog to store the alpine/helm:3.17.2 image

## Screenshots
### Using Private Image for Delete Job
values file:
<img width="684" height="273" alt="image" src="https://github.com/user-attachments/assets/573e9e33-9720-46c6-8e47-65c70f7de9bf" />

Uninstall Job with created Secret:
<img width="698" height="370" alt="image" src="https://github.com/user-attachments/assets/e45b9b24-5783-428d-ba7d-cd7d901359c9" />

Uninstallation Successful:
<img width="465" height="110" alt="image" src="https://github.com/user-attachments/assets/f2dd69f4-442c-4de4-a49a-64a3cdbc9686" />

Tested with and without creation of the dockerPullSecret for the delete Job.

### Optional creation of secrets
Secrets of konnector-docker-secret and distribution-id already exist:
<img width="619" height="160" alt="image" src="https://github.com/user-attachments/assets/fe170fa9-c9cb-4e74-a4d1-10051d19203b" />

Values file without distribution.id and dockerPullSecret:
<img width="579" height="167" alt="image" src="https://github.com/user-attachments/assets/68c1f9b8-2806-4524-b78b-cca158fbd62f" />

Successful installation:
<img width="929" height="331" alt="image" src="https://github.com/user-attachments/assets/7f778e72-28cf-49f6-8caf-b9d06767820b" />


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
