### PR TITLE
OpenShift Registry Scan Support

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: 3.x
+          python-version: '3.12'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: '3.12'
+          python-version: 3.x
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0

--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.24-rc.1
+version: 1.0.24-rc.2
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.24
+version: 1.0.23
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.23
+version: 1.0.24
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -28,6 +28,7 @@ optionalValues:
   CLUSTER_URI: ""    # Cluster URI should be set when metadata service is not reachable from the cluster
   UPLOAD_LOG_LEVEL: "ERROR"  # Log level for uploading logs ("ERROR", "WARNING", "INFO", "DEBUG", "PANIC")
   CONSOLE_LOG_LEVEL: "INFO"  # Log level for console output ("ERROR", "WARNING", "INFO", "DEBUG", "PANIC")
+  REGISTRY_SCAN_URL: "" # OpenShift registry scan URL — set by the user if a custom registry URL was configured
 
 proxyValues:
   httpProxy: ""  # Optional proxy URL for external network access

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -199,10 +199,6 @@ system:
       roleRef:
         apiGroup: security.openshift.io/v1
         name: system:openshift:scc:privileged
-    konnector-openshift-registry:
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io/v1
-        name: system:image-puller
 
   # ==========================
   # Secrets Resources

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -199,6 +199,10 @@ system:
       roleRef:
         apiGroup: security.openshift.io/v1
         name: system:openshift:scc:privileged
+    konnector-openshift-registry:
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io/v1
+        name: system:image-puller
 
   # ==========================
   # Secrets Resources

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -28,7 +28,7 @@ optionalValues:
   CLUSTER_URI: ""    # Cluster URI should be set when metadata service is not reachable from the cluster
   UPLOAD_LOG_LEVEL: "ERROR"  # Log level for uploading logs ("ERROR", "WARNING", "INFO", "DEBUG", "PANIC")
   CONSOLE_LOG_LEVEL: "INFO"  # Log level for console output ("ERROR", "WARNING", "INFO", "DEBUG", "PANIC")
-  REGISTRY_SCAN_URL: ""  # OpenShift registry scan URL - set by the user if a custom registry URL was configured
+  IN_CLUSTER_REGISTRY_SCAN_URL: ""  # OpenShift registry scan URL - set by the user if a custom registry URL was configured
 
 proxyValues:
   httpProxy: ""  # Optional proxy URL for external network access

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -28,7 +28,7 @@ optionalValues:
   CLUSTER_URI: ""    # Cluster URI should be set when metadata service is not reachable from the cluster
   UPLOAD_LOG_LEVEL: "ERROR"  # Log level for uploading logs ("ERROR", "WARNING", "INFO", "DEBUG", "PANIC")
   CONSOLE_LOG_LEVEL: "INFO"  # Log level for console output ("ERROR", "WARNING", "INFO", "DEBUG", "PANIC")
-  REGISTRY_SCAN_URL: "" # OpenShift registry scan URL — set by the user if a custom registry URL was configured
+  REGISTRY_SCAN_URL: ""  # OpenShift registry scan URL - set by the user if a custom registry URL was configured
 
 proxyValues:
   httpProxy: ""  # Optional proxy URL for external network access
@@ -199,6 +199,10 @@ system:
       roleRef:
         apiGroup: security.openshift.io/v1
         name: system:openshift:scc:privileged
+    konnector-openshift-registry:
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io/v1
+        name: system:image-puller
 
   # ==========================
   # Secrets Resources


### PR DESCRIPTION
## Description
Add OpenShift image puller permissions 
Add registry-scan-url env 

## Motivation and Context
Our agent can perform OpenShift registry image scans.
By default, we use the standard OpenShift registry URL.
If the customer changes this URL, they can set the REGISTRY_SCAN_URL environment variable with their custom URL.