### PR TITLE
delete finished jobs after 30 minutes

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: 3.x
+          python-version: 3.12
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0

--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.23
+version: 1.0.24
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/templates/_helpers.tpl
+++ b/charts/konnector/templates/_helpers.tpl
@@ -41,6 +41,7 @@ app.kubernetes.io/author: {{ .Values.namespace.name }}
 {{- define "common.jobTemplate" -}}
 spec:
   backoffLimit: {{ .Values.system.batch.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.system.batch.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/charts/konnector/templates/_helpers.tpl
+++ b/charts/konnector/templates/_helpers.tpl
@@ -38,6 +38,11 @@ app.kubernetes.io/author: {{ .Values.namespace.name }}
 {{- printf "%d */1 * * *" $minute -}}
 {{- end -}}
 
+{{- define "common.jobsHistoryLimit" -}}
+successfulJobsHistoryLimit: 1
+failedJobsHistoryLimit: 1
+{{- end -}}
+
 {{- define "common.jobTemplate" -}}
 spec:
   backoffLimit: {{ .Values.system.batch.backoffLimit }}

--- a/charts/konnector/templates/batch.yaml
+++ b/charts/konnector/templates/batch.yaml
@@ -19,6 +19,7 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 spec:
   schedule: {{ include "common.generateSchedule" . | quote }}
+  {{- include "common.jobsHistoryLimit" . | nindent 2 }}
   jobTemplate:
     {{- include "common.jobTemplate" . | nindent 4 }}
 ---

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -50,6 +50,7 @@ system:
   # ==========================
   batch:
     backoffLimit: 4  # Maximum number of retries before the job is considered failed. After 4 attempts, the job will fail.
+    ttlSecondsAfterFinished: 1800  # Automatically delete the job 30 minutes (1800 seconds) after it completes
 
   # ==========================
   # Service Account Resources

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -50,7 +50,6 @@ system:
   # ==========================
   batch:
     backoffLimit: 4  # Maximum number of retries before the job is considered failed. After 4 attempts, the job will fail.
-    ttlSecondsAfterFinished: 1800  # Automatically delete the job 30 minutes (1800 seconds) after it completes
 
   # ==========================
   # Service Account Resources


### PR DESCRIPTION
## Description

Configure the Job TTL to 30 minutes to ensure finished Jobs (successful or failed) are deleted promptly. 
(The default retention period is 6 hours.)