### PR TITLE
feat: add conditional initContainer for Prisma AIRS propagation

### DIFF
--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.24
+version: 1.0.25
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/templates/_helpers.tpl
+++ b/charts/konnector/templates/_helpers.tpl
@@ -67,8 +67,14 @@ spec:
       {{- if .Values.USE_PRISMA_AIRS }}
       initContainers:
         - name: fw-policy-wait
-          image: busybox:1.28
+          image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+          imagePullPolicy: {{ .Values.initContainerImage.pullPolicy }}
           command: ['sh', '-c', 'echo "Waiting for PAN-CNI propagation..."; sleep 30;']
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+          resources:
+            {{- toYaml .Values.initContainerImage.resources | nindent 12 }}
       {{- end }}
       volumes:
         - name: {{ .Values.system.secrets.backendAuth.name }}

--- a/charts/konnector/templates/_helpers.tpl
+++ b/charts/konnector/templates/_helpers.tpl
@@ -64,6 +64,12 @@ spec:
       {{- if .Values.priorityClassValues.enabled }}
       priorityClassName: {{ .Values.priorityClassValues.classes.high.name }}
       {{- end }}
+      {{- if .Values.USE_PRISMA_AIRS }}
+      initContainers:
+        - name: fw-policy-wait
+          image: busybox:1.28
+          command: ['sh', '-c', 'echo "Waiting for PAN-CNI propagation..."; sleep 30;']
+      {{- end }}
       volumes:
         - name: {{ .Values.system.secrets.backendAuth.name }}
           secret:

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -2,7 +2,7 @@
 # ### Customer Defined Values ###
 # ==========================
 
-USE_PRISMA_AIRS: false  # Enable conditional initContainer for Prisma AIRS propagation wait
+USE_PRISMA_AIRS: true  # Enable conditional initContainer for Prisma AIRS propagation wait
 
 initContainerImage:
   repository: busybox

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -2,7 +2,7 @@
 # ### Customer Defined Values ###
 # ==========================
 
-USE_PRISMA_AIRS: true  # Enable conditional initContainer for Prisma AIRS propagation wait
+USE_PRISMA_AIRS: false  # Enable conditional initContainer for Prisma AIRS propagation wait
 
 initContainerImage:
   repository: busybox

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -1,6 +1,8 @@
 # ==========================
 # ### Customer Defined Values ###
 # ==========================
+
+USE_PRISMA_AIRS: false  # Enable conditional initContainer for Prisma AIRS propagation wait
 # All values below are defined by the customer for a specific installation.
 # These values must be customized according to the installation environment.
 #

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -3,6 +3,19 @@
 # ==========================
 
 USE_PRISMA_AIRS: false  # Enable conditional initContainer for Prisma AIRS propagation wait
+
+initContainerImage:
+  repository: busybox
+  tag: 1.28
+  pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
+
 # All values below are defined by the customer for a specific installation.
 # These values must be customized according to the installation environment.
 #


### PR DESCRIPTION
## Summary
This PR introduces a conditional `initContainer` to the `common.jobTemplate` helper. This allows `konnector` workloads to wait for the PAN-CNI (Prisma AIRS) network propagation before starting the main container, preventing connection failures during pod startup.

The logic is controlled by a new Helm value `USE_PRISMA_AIRS` (default: `false`), ensuring **no impact** on existing deployments unless explicitly enabled.

## Motivation & Context
We observed that in certain clusters using Prisma AIRS, pods fail to connect to the backend immediately upon startup because the network policy/CNI has not yet fully propagated.
* **Issue:** Pods start before network connectivity is stable.
* **Fix:** An `initContainer` (`fw-policy-wait`) sleeps for 30 seconds to allow the CNI to stabilize.
* **Scope:** This affects the `konnector` and related batch jobs utilizing `common.jobTemplate`.

## Technical Implementation
1.  **`values.yaml`**:
    * Added `USE_PRISMA_AIRS` boolean (default: `false`).
    * Added `initContainerImage` object to allow configuration of the image repository, tag, pull policy, and resources.
2.  **`_helpers.tpl`**:
    * Updated `common.jobTemplate` to conditionally inject the `fw-policy-wait` initContainer.
    * **Security:** Added `securityContext` (`runAsNonRoot: true`, `runAsUser: 65534`) to comply with enterprise security policies (OPA/PSA).
    * **Reliability:** Added configurable resource requests/limits (`cpu: 10m`, `memory: 32Mi`) to prevent scheduling issues.

## Test Plan
**1. Regression Test (Default Behavior):**
* Ran `helm template .` with default values (`USE_PRISMA_AIRS: false`).
* **Result:** Verified that `initContainers` is **NOT** present in the `Job` or `CronJob` specs.

**2. Feature Test (Enabled Behavior):**
* Ran `helm template . --set USE_PRISMA_AIRS=true`
* **Result:** `initContainers` is correctly injected into the Syncer Job and CronJob.
* **Verification:** Confirmed `securityContext` (runAsUser: 65534) and `resources` are rendered with correct indentation.
