### PR TITLE
fix(konnector): reset secret values on install and upgrade

### DIFF
--- a/charts/konnector/templates/_helpers.tpl
+++ b/charts/konnector/templates/_helpers.tpl
@@ -127,20 +127,3 @@ spec:
 {{ $groups | toYaml }}
 {{- end }}
 
-{{/*
-Return a base64 value for a Secret key:
-- If an existing Secret is present: reuse existing.data[key] (already base64).
-  If that key is missing, fall back to base64 of "" (or change to seed if you prefer).
-- If no existing Secret: use base64 of the provided seed.
-Usage: {{ include "secret.valueOrExistingB64" (dict "existing" $existing "key" "token" "seed" "--set-by-konnnector-at-runtime--") }}
-*/}}
-{{- define "secret.valueOrExistingB64" -}}
-{{- $existing := .existing -}}
-{{- $key := .key -}}
-{{- $seed := .seed | default "--set-by-konnnector-at-runtime--" -}}
-{{- if $existing -}}
-  {{- index $existing.data $key | default (b64enc "") | quote -}}
-{{- else -}}
-  {{- b64enc $seed | quote -}}
-{{- end -}}
-{{- end -}}

--- a/charts/konnector/templates/secret.yaml
+++ b/charts/konnector/templates/secret.yaml
@@ -1,18 +1,18 @@
-{{- $ns := $.Values.namespace.name -}}
-{{- $name := $.Values.system.secrets.backendAuth.name -}}
-{{- $existing := lookup "v1" "Secret" $ns $name -}}
+{{- /* NOTE: "konnnector" typo (3 n's) is intentional - maintained for backward compatibility */ -}}
+{{- $seed := "--set-by-konnnector-at-runtime--" -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $name }}
-  namespace: {{ $ns }}
+  name: {{ .Values.system.secrets.backendAuth.name }}
+  namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
 type: Opaque
-data:
-  {{- range $k := list "token" "refreshToken" "sosToken" "chapi" }}
-  {{ $k }}: {{ include "secret.valueOrExistingB64" (dict "existing" $existing "key" $k "seed" "--set-by-konnnector-at-runtime--") }}
-  {{- end }}
+stringData:
+  token: {{ $seed | quote }}
+  refreshToken: {{ $seed | quote }}
+  sosToken: {{ $seed | quote }}
+  chapi: {{ $seed | quote }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
- Remove secret.valueOrExistingB64 helper that preserved existing values
- Use stringData with placeholder values that get reset on each deploy
- Ensures konnector re-authenticates after helm install/upgrade
- Remove unused lookup logic from _helpers.tpl

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
