### PR TITLE
feat: add conditional Docker pull secret creation

### DIFF
--- a/charts/konnector/templates/_helpers.tpl
+++ b/charts/konnector/templates/_helpers.tpl
@@ -144,3 +144,34 @@ Usage: {{ include "secret.valueOrExistingB64" (dict "existing" $existing "key" "
   {{- b64enc $seed | quote -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Backward compatibility: determine if dockerPullSecret should be created
+Supports both old string format and new structured format
+*/}}
+{{- define "dockerPullSecret.shouldCreate" -}}
+{{- if typeIs "map[string]interface {}" .Values.dockerPullSecret -}}
+  {{- if .Values.dockerPullSecret.create -}}
+    {{- "true" -}}
+  {{- else -}}
+    {{- "false" -}}
+  {{- end -}}
+{{- else -}}
+  {{- "true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backward compatibility: get dockerPullSecret data
+Supports both old string format and new structured format
+*/}}
+{{- define "dockerPullSecret.data" -}}
+{{- if typeIs "map[string]interface {}" .Values.dockerPullSecret -}}
+  {{- .Values.dockerPullSecret.data | default "" -}}
+{{- else if typeIs "string" .Values.dockerPullSecret -}}
+  {{- .Values.dockerPullSecret -}}
+{{- else -}}
+  {{- "" -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/konnector/templates/secret.yaml
+++ b/charts/konnector/templates/secret.yaml
@@ -14,6 +14,7 @@ data:
   {{ $k }}: {{ include "secret.valueOrExistingB64" (dict "existing" $existing "key" $k "seed" "--set-by-konnnector-at-runtime--") }}
   {{- end }}
 ---
+{{- if eq (include "dockerPullSecret.shouldCreate" .) "true" }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
@@ -23,7 +24,8 @@ metadata:
   labels:
     {{- include "common.labels" . | nindent 4 }}
 data:
-  .dockerconfigjson: {{ .Values.dockerPullSecret | default ( "{}" | b64enc ) }}
+  .dockerconfigjson: {{ include "dockerPullSecret.data" . | default ( "{}" | b64enc ) }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -18,7 +18,13 @@ image:
 namespace:
   name: pan  # Kubernetes namespace where resources will be deployed
 
-dockerPullSecret: ""  # Secret for pulling images from a private registry
+# Docker Pull Secret Configuration
+# Set 'create: true' to have Helm create the secret (requires 'data' to be provided)
+# Set 'create: false' to skip creation (assumes secret will be provisioned externally)
+
+dockerPullSecret:
+  create: true  # Set to false if secret is managed externally
+  data: ""      # Base64-encoded Docker config JSON (only used if create: true)
 
 distribution:
   id: "default-distribution-id"  # Retrieve distribution ID from Palo Alto Networks systems during installation


### PR DESCRIPTION
Introduces dockerPullSecret.create flag to support external secret management. Maintains backward compatibility with legacy string format.

## Description

This PR adds conditional secret creation for the Docker pull secret in the konnector Helm chart. Users can now set dockerPullSecret.create: false to skip Helm-managed secret creation and provision secrets externally (e.g., via External Secrets Operator, Vault, or manual provisioning).

Key changes:

Converted dockerPullSecret from a simple string to a structured object with create flag and data field
Added backward compatibility helpers in _helpers.tpl to support both old (string) and new (object) formats
Wrapped Docker pull secret creation in conditional logic in secret.yaml

## Motivation and Context

Currently, the chart requires Docker pull secret credentials to be provided directly in values.yaml, which creates security risks:

- Risk of accidentally committing sensitive credentials to Git repositories
- Requires complex workarounds (e.g., encrypted values files, separate secret values) for GitOps workflows
- No native support for external secret management tools (External Secrets Operator, Vault, etc.)

This change enables secure credential management by allowing users to provision secrets externally while maintaining full backward compatibility with existing deployments.

## How Has This Been Tested?

Test Environment: Local development with Helm 3.x

Test Scenarios:

1. Regression Test (Default Behavior)

```bash
helm template . --values=values.yaml
```

✅ Verified konnector-docker-secret is created with default empty config
✅ Backward compatible with original behavior

2. Feature Test (Disabled Creation)

```bash
helm template . --set dockerPullSecret.create=false
```
✅ Verified konnector-docker-secret is NOT created
✅ Allows external secret management

3. Backward Compatibility Test (Old String Format)

```bash
helm template . --set dockerPullSecret="eyJhdXRocyI6e319Cg=="
```
✅ Secret created with provided data
✅ Existing deployments continue to work without modification

4. Feature Test (Enabled with Custom Data)

```bash
helm template . --set dockerPullSecret.create=true --set dockerPullSecret.data="eyJhdXRocyI6e319Cg=="
```
✅ Secret created with custom Docker credentials

## Screenshots (if appropriate)

N/A - Helm chart changes only

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
