### PR TITLE
fix: reset auth secret when distribution ID changes during upgrade

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -26,6 +26,12 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 0.6.3
+
+      - name: Run helm unit tests
+        run: helm unittest charts/konnector
+
       - name: Validate konnector chart version
         shell: bash
         run: |

--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.24
+version: 1.0.25
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/templates/secret.yaml
+++ b/charts/konnector/templates/secret.yaml
@@ -1,6 +1,19 @@
 {{- $ns := $.Values.namespace.name -}}
 {{- $name := $.Values.system.secrets.backendAuth.name -}}
-{{- $existing := lookup "v1" "Secret" $ns $name -}}
+{{- $existingAuth := lookup "v1" "Secret" $ns $name -}}
+{{- $distributionChanged := false -}}
+{{- if not (kindIs "invalid" $.Values._testing.distributionChanged) -}}
+  {{- $distributionChanged = $.Values._testing.distributionChanged -}}
+{{- else -}}
+  {{- $existingDistSecret := lookup "v1" "Secret" $ns "distribution-id" -}}
+  {{- if $existingDistSecret -}}
+    {{- $existingDistID := index $existingDistSecret.data "distribution-id" | default "" | b64dec -}}
+    {{- if ne $existingDistID $.Values.distribution.id -}}
+      {{- $distributionChanged = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $existing := ternary nil $existingAuth $distributionChanged -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/konnector/tests/secret_test.yaml
+++ b/charts/konnector/tests/secret_test.yaml
@@ -1,0 +1,283 @@
+suite: Secret template tests
+templates:
+  - templates/secret.yaml
+values:
+  - ../values.yaml
+set:
+  distribution.id: "test-distribution-id"
+  image.repository: "test-repo"
+  image.name: "test-image"
+  image.tag: "test-tag"
+tests:
+  # ============================================================
+  # Backend Auth Secret Tests
+  # ============================================================
+  - it: should render backend-auth-secret with correct metadata
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: backend-auth-secret
+      - equal:
+          path: metadata.namespace
+          value: pan
+      - equal:
+          path: type
+          value: Opaque
+
+  - it: should contain all four auth keys with seed values on fresh install
+    documentIndex: 0
+    asserts:
+      - exists:
+          path: data.token
+      - exists:
+          path: data.refreshToken
+      - exists:
+          path: data.sosToken
+      - exists:
+          path: data.chapi
+
+  - it: should use seed values when no existing secret is found (fresh install)
+    documentIndex: 0
+    asserts:
+      # On fresh install, lookup returns nil, so seed value is base64-encoded
+      # seed = "--set-by-konnnector-at-runtime--" → base64 = "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+      - equal:
+          path: data.token
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+      - equal:
+          path: data.refreshToken
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+      - equal:
+          path: data.sosToken
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+      - equal:
+          path: data.chapi
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+
+  # ============================================================
+  # Docker Secret Tests
+  # ============================================================
+  - it: should render docker secret with correct metadata
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: konnector-docker-secret
+      - equal:
+          path: metadata.namespace
+          value: pan
+      - equal:
+          path: type
+          value: kubernetes.io/dockerconfigjson
+
+  - it: should use default empty dockerconfigjson when no pull secret is provided
+    documentIndex: 1
+    asserts:
+      - exists:
+          path: data[".dockerconfigjson"]
+
+  - it: should use provided dockerPullSecret value
+    documentIndex: 1
+    set:
+      dockerPullSecret: "eyJhdXRocyI6e319"
+    asserts:
+      - equal:
+          path: data[".dockerconfigjson"]
+          value: "eyJhdXRocyI6e319"
+
+  # ============================================================
+  # Distribution ID Secret Tests
+  # ============================================================
+  - it: should render distribution-id secret with correct metadata
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: distribution-id
+      - equal:
+          path: metadata.namespace
+          value: pan
+      - equal:
+          path: type
+          value: Opaque
+
+  - it: should set distribution-id from values
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: stringData.distribution-id
+          value: "test-distribution-id"
+
+  - it: should use custom distribution id when overridden
+    documentIndex: 2
+    set:
+      distribution.id: "custom-dist-id-12345"
+    asserts:
+      - equal:
+          path: stringData.distribution-id
+          value: "custom-dist-id-12345"
+
+  # ============================================================
+  # Proxy Secret Tests
+  # ============================================================
+  - it: should render proxy secret with correct metadata
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: konnector-proxy
+      - equal:
+          path: metadata.namespace
+          value: pan
+      - equal:
+          path: type
+          value: Opaque
+
+  - it: should have default proxy values
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: stringData.httpProxy
+          value: ""
+      - equal:
+          path: stringData.noProxy
+          value: "kubernetes,kubernetes.default.svc,.svc,.cluster.local"
+
+  - it: should use custom proxy values when provided
+    documentIndex: 3
+    set:
+      proxyValues.httpProxy: "http://proxy.example.com:8080"
+      proxyValues.noProxy: "localhost,127.0.0.1"
+    asserts:
+      - equal:
+          path: stringData.httpProxy
+          value: "http://proxy.example.com:8080"
+      - equal:
+          path: stringData.noProxy
+          value: "localhost,127.0.0.1"
+
+  # ============================================================
+  # Labels Tests
+  # ============================================================
+  - it: should include common labels on all secrets
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: konnector
+      - equal:
+          path: metadata.labels["app.kubernetes.io/author"]
+          value: pan
+
+  - it: should include common labels on distribution-id secret
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: konnector
+      - equal:
+          path: metadata.labels["app.kubernetes.io/author"]
+          value: pan
+
+  # ============================================================
+  # Custom Namespace Tests
+  # ============================================================
+  - it: should use custom namespace for all secrets
+    set:
+      namespace.name: "custom-ns"
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: should use custom namespace for docker secret
+    set:
+      namespace.name: "custom-ns"
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: should use custom namespace for distribution-id secret
+    set:
+      namespace.name: "custom-ns"
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: should use custom namespace for proxy secret
+    set:
+      namespace.name: "custom-ns"
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  # ============================================================
+  # Distribution ID Change — Auth Secret Reset Tests
+  # ============================================================
+  # These tests use _testing.distributionChanged to simulate the
+  # lookup-based detection that normally runs against a live cluster.
+
+  - it: should reset auth tokens to seed values when distribution ID changes
+    documentIndex: 0
+    set:
+      _testing.distributionChanged: true
+    asserts:
+      # When distribution ID changes, all auth tokens must be reset to seed values
+      - equal:
+          path: data.token
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+      - equal:
+          path: data.refreshToken
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+      - equal:
+          path: data.sosToken
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+      - equal:
+          path: data.chapi
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+
+  - it: should preserve auth tokens when distribution ID has not changed
+    documentIndex: 0
+    set:
+      _testing.distributionChanged: false
+    asserts:
+      # When distribution ID is the same, tokens should be preserved (in unit test
+      # context, lookup returns nil so seed values are used — but the code path
+      # that would preserve existing tokens is exercised)
+      - exists:
+          path: data.token
+      - exists:
+          path: data.refreshToken
+      - exists:
+          path: data.sosToken
+      - exists:
+          path: data.chapi
+
+  - it: should default to lookup-based detection when _testing.distributionChanged is null
+    documentIndex: 0
+    asserts:
+      # With _testing.distributionChanged=null (default), the template falls through
+      # to the lookup-based detection. In unit tests, lookup returns nil so
+      # distributionChanged=false and seed values are used (fresh install behavior).
+      - equal:
+          path: data.token
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="
+      - equal:
+          path: data.refreshToken
+          value: "LS1zZXQtYnkta29ubm5lY3Rvci1hdC1ydW50aW1lLS0="

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -267,3 +267,12 @@ system:
                   values:
                     - amd64
                     - arm64
+
+# ==========================
+# ### Testing Overrides ###
+# ==========================
+# Internal values used for unit testing only. Do NOT set in production.
+# When _testing.distributionChanged is set (true/false), it overrides the
+# runtime lookup-based detection of distribution ID changes.
+_testing:
+  distributionChanged: null


### PR DESCRIPTION
Previously, upgrading the chart with a different distribution.id would preserve the backend-auth-secret tokens from the old distribution. These stale credentials would cause authentication failures since they belong to the previous distribution.

The secret template now compares the existing distribution-id secret in the cluster against the incoming .Values.distribution.id. When they differ, the auth tokens (token, refreshToken, sosToken, chapi) are reset to seed values, allowing the konnector to re-authenticate with the new distribution.

A _testing.distributionChanged override was added to values.yaml to enable unit testing of the distribution-change code path, since Helm's lookup function is unavailable in helm-unittest.

Also adds helm-unittest to the CI pipeline with 21 tests covering secret template rendering, distribution ID change detection, and auth token reset behavior.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
