### PR TITLE
feat: constrain all pods to run on Linux nodes only

### DIFF
--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.24
+version: 1.0.25
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/templates/_helpers.tpl
+++ b/charts/konnector/templates/_helpers.tpl
@@ -53,6 +53,8 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app.kubernetes.io/component: {{ .Release.Name }}
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       {{- with .Values.system.apps.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/konnector/templates/batch.yaml
+++ b/charts/konnector/templates/batch.yaml
@@ -35,6 +35,8 @@ spec:
   backoffLimit: 0
   template:
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       serviceAccountName: {{ .Values.system.serviceAccount.name }}
       restartPolicy: "Never"
       {{- if .Values.priorityClassValues.enabled }}


### PR DESCRIPTION
Add nodeSelector with kubernetes.io/os: linux to all pod specs:
- common.jobTemplate in _helpers.tpl (used by Job and CronJob)
- pre-delete hook Job in batch.yaml

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
