### PR TITLE
feat(kcli): add Cortex Cloud konnector image-mirroring CLI

### DIFF
--- a/tools/kcli/.gitignore
+++ b/tools/kcli/.gitignore
@@ -1,0 +1,5 @@
+# Local scratch / build output
+cortex-mirror-output/
+tmp/
+*.log
+.DS_Store

--- a/tools/kcli/LICENSE
+++ b/tools/kcli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) Palo Alto Networks
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tools/kcli/README.md
+++ b/tools/kcli/README.md
@@ -1,0 +1,545 @@
+# kcli
+
+> Cortex Cloud konnector CLI — currently focused on **mirroring konnector
+> container images** to a private container registry.
+
+`kcli` is a small, focused command-line tool for operating the Palo Alto
+Networks Cortex Cloud konnector Helm chart in **air-gapped or
+private-registry** environments.
+
+The first (and currently only) subcommand is `kcli mirror`. Given the
+konnector Helm chart archive (`.tgz`, bundle v2+) and the operator's
+Helm values file, it will:
+
+1. Verify the chart advertises a supported konnector bundle version
+   (`Chart.yaml` `version` major `>= 2`; `appVersion` is used as a
+   fallback when `version` is missing).
+2. Pull every container image declared by the chart under
+   `global.bundle.<comp>.image` from the source registry, preserving
+   multi-arch manifests.
+3. Re-push them into a private container registry of your choice.
+4. **Rewrite the operator's `--values` file in place** so it points the
+   chart at the mirrored registry — setting `global.imageRegistry`, any
+   per-component `global.bundle.<comp>.image.repository` overrides that
+   already exist, and (optionally) `global.dockerPullSecret`. A
+   timestamped `.bak` copy of the original file is written next to it
+   before any change.
+
+The mirroring logic is functionally equivalent to the
+`cortex-installer mirror` subcommand on the
+[`standalone-installer`](https://github.com/PaloAltoNetworks/cortex-cloud/tree/standalone-installer)
+branch, packaged with a CLI structure modelled after
+[PaloAltoNetworks/ktool](https://github.com/PaloAltoNetworks/ktool/blob/main/kubectl-ktool.sh)
+(subcommand dispatcher, dedicated `version` command, semver
+`parse_major_version` helper).
+
+> 🔧 **Installation of the chart itself is not in scope for this tool.**
+> After `kcli mirror` finishes, follow the installation instructions for
+> your tenant in the **Cortex Cloud portal** — the portal is the
+> single source of truth for the canonical install flow.
+
+---
+
+## Table of contents
+
+- [Why this tool?](#why-this-tool)
+- [Bundle compatibility](#bundle-compatibility)
+- [How it works](#how-it-works)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Staying current (mandatory version check)](#staying-current-mandatory-version-check)
+- [Commands](#commands)
+  - [`kcli mirror`](#kcli-mirror)
+  - [`kcli version`](#kcli-version)
+  - [`kcli help`](#kcli-help)
+- [Inputs](#inputs)
+- [`dockerPullSecret` semantics](#dockerpullsecret-semantics)
+- [What `kcli mirror` writes](#what-kcli-mirror-writes)
+- [Environment variables](#environment-variables)
+- [Exit codes](#exit-codes)
+- [Logging & diagnostics](#logging--diagnostics)
+- [Security notes](#security-notes)
+- [License](#license)
+
+---
+
+## Why this tool?
+
+The default konnector install pulls images directly from the Palo Alto
+Networks distribution registry. In environments where worker nodes cannot
+reach the public internet — or where customer policy mandates that all
+container images live in an internal registry — operators need to:
+
+1. Discover **which images** the chart needs for the customer's bundle
+   subscription.
+2. Pull every image (across all supported architectures).
+3. Re-push them into a private registry under stable tags.
+4. Patch the chart's `global.imageRegistry` (and any per-component
+   overrides) so pods pull from the new location.
+5. Update `global.dockerPullSecret` so Kubernetes nodes can authenticate
+   to the private registry.
+
+`kcli mirror` automates steps 1–5. The end-state is the operator's same
+`--values` file, mutated in place to point at the mirrored registry, ready
+to be passed straight into the chart install (per the Cortex Cloud portal
+flow).
+
+---
+
+## Bundle compatibility
+
+This tool supports konnector **bundle v2 or higher** only. The version
+gate is read from the chart archive's `Chart.yaml`:
+
+```yaml
+# inside the .tgz: konnector-bundle/Chart.yaml
+apiVersion: v2
+name: konnector-bundle
+version: 2.0.41        # ← bundle version gate; major must be >= 2
+appVersion: v2.0.41    # fallback if 'version' is absent
+```
+
+The customer **values file** (`--values`) stays minimal — it supplies
+the source registry, the source-registry pull secret, and the
+deployment environment used to resolve per-env image tags:
+
+```yaml
+global:
+  imageRegistry: "us-docker.pkg.dev/cortex-konnector/konnector"
+  dockerPullSecret: "<base64-encoded-docker-config-json>"
+  metadata:
+    env: "prod"   # one of: dev | prod | fr | gov
+```
+
+The list of mirrorable images is read from the chart's own `values.yaml`
+under `global.bundle.<comp>.image` — every component the chart knows
+about is mirrored. Components whose tag is provided per-env (e.g.
+`cortex-agent` ships as `image.tagsByEnv.{dev,prod,fr,gov}` instead of
+a static `image.tag`) are resolved against `global.metadata.env`.
+
+`kcli mirror` reads:
+
+| What                            | Path                                                                |
+|---------------------------------|---------------------------------------------------------------------|
+| Bundle version (gate)           | `version` (with `appVersion` fallback) from chart `Chart.yaml`      |
+| Source registry / repo path     | `global.imageRegistry` (from `--values`)                            |
+| Source-registry pull credentials| `global.dockerPullSecret` (from `--values`)                         |
+| Deployment env (per-env tags)   | `global.metadata.env` (from `--values`) — `dev`/`prod`/`fr`/`gov`   |
+| Mirrorable image catalog        | `global.bundle.<comp>.image` (from chart `values.yaml`)             |
+
+…and **rewrites** the operator's `--values` file in place:
+`global.imageRegistry` and any per-component
+`global.bundle.<comp>.image.repository` overrides that already exist are
+pointed at the mirror, plus `global.dockerPullSecret` is set/removed per
+the CLI flags.
+
+Older bundles are **not supported** by this mirror flow — `kcli mirror`
+exits with exit code `1` and a clear error message before any registry
+traffic happens:
+
+```text
+[ERROR] Unsupported bundle version: chart version = '1.5.0' (major=1).
+[ERROR] The mirror flow requires konnector bundle v2 or higher.
+[ERROR] Please upgrade to a v2+ bundle and retry.
+```
+
+The version-parsing helper (`parse_major_version`) follows the same
+convention as
+[ktool](https://github.com/PaloAltoNetworks/ktool/blob/main/kubectl-ktool.sh):
+a leading `v` is optional and pre-release/build metadata is ignored.
+
+---
+
+## How it works
+
+```
+┌──────────────────────────┐     ┌─────────────────────────────────────┐
+│  --chart  <chart.tgz>    │     │  Source container registry          │
+│  --values <values.yaml>  │ ──► │  (defined by global.imageRegistry   │
+│   (global.bundle.*       │     │   in --values; auth via             │
+│    declares enabled      │     │   global.dockerPullSecret)          │
+│    components)           │     └────────────────┬────────────────────┘
+└──────────────────────────┘                      │ docker pull (multi-arch)
+                                                  ▼
+                                  ┌──────────────────────────────────────┐
+                                  │  Local Docker daemon                 │
+                                  └────────────────┬─────────────────────┘
+                                                   │ buildx imagetools create
+                                                   ▼
+                                  ┌──────────────────────────────────────┐
+                                  │  --private-registry                  │
+                                  └──────────────────────────────────────┘
+
+In-place edit:
+  --values <file>  →  global.imageRegistry        := <push-target>
+                      global.bundle[*].image.repository (where present)
+                                                  := <push-target>
+                      global.dockerPullSecret     := <secret>  (if provided)
+                      <file>.bak.<UTC-timestamp>  ← byte-for-byte original
+```
+
+---
+
+## Prerequisites
+
+| Tool             | Minimum version | Why                                          |
+|------------------|-----------------|----------------------------------------------|
+| `bash`           | 4.0             | Arrays, `[[ … ]]`, traps                     |
+| `docker`         | 20.10           | Image pull/push                              |
+| `docker buildx`  | bundled         | Multi-arch manifest copy                     |
+| `curl`           | any             | Mandatory upstream-version check (skipped if absent) |
+| `jq`             | 1.6             | JSON manipulation                            |
+| `yq`             | 4.x (mikefarah) | YAML manipulation (the **Go** version)       |
+| `tar`            | any             | Chart-archive extraction                     |
+| `base64`         | GNU or BSD      | Decoding the dockerPullSecret                |
+
+The tool detects missing prerequisites and prints actionable error messages
+before doing any work.
+
+> ⚠️ **Note:** the python `yq` (`pip install yq`) is **not** compatible —
+> install the Go binary from <https://github.com/mikefarah/yq>.
+
+---
+
+## Installation
+
+`kcli` is a single self-contained bash script. There are no release
+artifacts — the canonical copy lives at `tools/kcli/kcli` on the
+`main` branch of this repository, and that file is exactly what you
+run.
+
+### Clone & symlink (recommended)
+
+```bash
+git clone https://github.com/PaloAltoNetworks/cortex-cloud.git
+cd cortex-cloud
+sudo ln -sf "$PWD/tools/kcli/kcli" /usr/local/bin/kcli
+kcli version
+```
+
+To stay current, just pull the latest `main`:
+
+```bash
+cd /path/to/cortex-cloud
+git pull origin main
+```
+
+### Direct download (no clone)
+
+```bash
+sudo curl -fsSL \
+  https://raw.githubusercontent.com/PaloAltoNetworks/cortex-cloud/main/tools/kcli/kcli \
+  -o /usr/local/bin/kcli
+sudo chmod +x /usr/local/bin/kcli
+kcli version
+```
+
+To update later, re-run the same `curl` to overwrite the file in place.
+
+### Run from source
+
+```bash
+./tools/kcli/kcli help
+```
+
+---
+
+## Staying current (mandatory version check)
+
+Every invocation of `kcli` (other than `version` / `help`) parses the
+`VERSION="x.y.z"` constant out of the canonical copy on `main` and
+compares it to the local one. When the local script is older, `kcli`
+**hard-fails before running anything** with an actionable remediation
+message:
+
+```text
+[ERROR] A newer kcli version is available.
+[ERROR]   installed: v1.0.0
+[ERROR]   upstream:  v1.1.0
+[ERROR]
+[ERROR] kcli requires the latest version. Update before retrying:
+[ERROR]   - If installed via 'git clone':  cd <repo> && git pull
+[ERROR]   - If installed by file copy:     re-fetch tools/kcli/kcli from
+[ERROR]       https://raw.githubusercontent.com/PaloAltoNetworks/cortex-cloud/main/tools/kcli/kcli
+```
+
+The exit code in this case is `65` (data-format mismatch), distinct
+from the usage error (`64`) and runtime errors (`1`) so CI pipelines
+can distinguish "needs update" from "real failure".
+
+### When the check is skipped
+
+The check is best-effort by design — it must never become a footgun
+for legitimate operators on slow / restricted networks. It is skipped,
+with a `[WARN]` line, in any of:
+
+- `curl` is not installed.
+- The GitHub fetch times out (5 s) or returns no parseable VERSION.
+- `KCLI_SKIP_VERSION_CHECK=1` is exported (for air-gapped /
+  internally-vendored installs where remote fetch is impossible by
+  policy).
+
+In all skip cases the local script still runs — operators just don't
+get the "you're stale" guarantee.
+
+### Local builds ahead of upstream
+
+If your local `VERSION` is *higher* than the one on `main` (e.g.
+you're working on a feature branch), `kcli` warns once and proceeds
+— development builds are explicitly allowed to run.
+
+---
+
+## Commands
+
+```text
+kcli <command> [options]
+
+Commands:
+  mirror     Pull bundle container images from the source registry and push
+             them to a private registry (preserving multi-arch manifests).
+             Updates the --values file in place to point at the mirror
+             (a timestamped .bak is written first).
+  version    Print the kcli version.
+  help       Show top-level help.
+```
+
+### `kcli mirror`
+
+```text
+Usage:
+  kcli mirror --chart <chart.tgz> --values <values-file> \
+              --private-registry <registry> [options]
+
+Required:
+  --chart <chart.tgz>              Path to the konnector Helm chart archive
+                                   (the .tgz issued for your tenant)
+  --values <values-file>           Helm values YAML (read AND written in place
+                                   — provides global.bundle.* enable map,
+                                   source-registry credentials, and gets
+                                   rewritten to point at the mirror)
+  --private-registry <registry>    Target registry, e.g.
+                                   myregistry.azurecr.io/proj/repo
+
+Optional:
+  --docker-pull-secret <secret>    Base64-encoded dockerPullSecret for the
+                                   private registry (written into the
+                                   --values file under global.dockerPullSecret)
+  --docker-pull-secret-file <file> Path to a Docker config JSON for the
+                                   private registry (will be base64-encoded
+                                   and written as global.dockerPullSecret)
+  --no-pull-secret                 Strip global.dockerPullSecret from the
+                                   --values file (use only if the cluster
+                                   already has access)
+  --dry-run                        Show what would be done without pulling
+                                   or pushing images. The --values file is
+                                   NOT rewritten in dry-run mode.
+  -h, --help                       Show command help
+```
+
+#### Quick start
+
+```bash
+kcli mirror \
+  --chart ./konnector-2.0.0.tgz \
+  --values ./my-values.yaml \
+  --private-registry myregistry.azurecr.io/cortex \
+  --docker-pull-secret-file ~/.docker/config.json
+```
+
+After mirroring completes, install the konnector chart by following the
+**Cortex Cloud portal** instructions for your tenant, passing the
+(now-rewritten) `./my-values.yaml` as the Helm values file.
+
+#### Behaviour highlights
+
+- **Bundle-version gate.** Before any registry traffic, the chart's
+  `global.version` is verified to be `>= v2`; older bundles fail fast
+  with an actionable error message (see [Bundle compatibility](#bundle-compatibility)).
+- **Multi-arch awareness.** Each image is inspected via
+  `docker manifest inspect`. Every `linux/*` platform is pulled
+  individually, and the destination tag is created with
+  `docker buildx imagetools create` so the multi-arch index is preserved.
+- **Single-arch fallback.** If `buildx imagetools` fails for some reason,
+  the tool falls back to `docker tag` + `docker push` and reports the
+  result as a single-arch push.
+- **Per-component repository overrides.** When the values file contains
+  `global.bundle.<component>.image.repository`, those entries are also
+  rewritten to point at the mirror; entries without an explicit
+  `repository` are left untouched (no spurious key is injected).
+- **Backup before mutation.** A timestamped copy
+  `<values-file>.bak.YYYYMMDDTHHMMSSZ` is written before the rewrite, so
+  you can always roll back with `mv <values-file>.bak.* <values-file>`.
+- **Dry-run** (`--dry-run`) skips every network operation, leaves the
+  `--values` file untouched (no rewrite, no `.bak`), and prints exactly
+  what would have happened — useful for change-management reviews.
+
+### `kcli version`
+
+```bash
+$ kcli version
+kcli v1.0.0
+
+# `-v` and `--version` are accepted as aliases:
+$ kcli --version
+kcli v1.0.0
+```
+
+The version string is the `VERSION="x.y.z"` constant declared at the
+top of `tools/kcli/kcli`. See
+[Staying current (mandatory version check)](#staying-current-mandatory-version-check)
+for how this value is compared against the canonical copy on
+`main` on every invocation.
+
+### `kcli help`
+
+```bash
+kcli help
+kcli --help
+kcli -h
+```
+
+All three forms print the top-level usage. For command-specific help, use
+`kcli <command> --help` (e.g. `kcli mirror --help`).
+
+---
+
+## Inputs
+
+`kcli mirror` takes two file inputs:
+
+| Flag       | What                                                                |
+|------------|---------------------------------------------------------------------|
+| `--chart`  | The konnector Helm chart archive (`.tgz` or `.tar.gz`, bundle v2+). |
+| `--values` | The customer values YAML issued for your tenant.                    |
+
+The values file only carries what is tenant-specific:
+
+- `global.imageRegistry` — source registry / repo path used for pull.
+- `global.dockerPullSecret` — base64 Docker config used to authenticate
+  against the **source** registry (and the field `kcli` rewrites with
+  the **private** registry credential at the end of the run).
+- `global.metadata.env` — deployment environment (one of
+  `dev` / `prod` / `fr` / `gov`). Used to resolve per-env image tags
+  from the chart's `image.tagsByEnv.<env>` map. Components whose tag
+  is supplied only via `tagsByEnv` (e.g. `cortex-agent`) are SKIPPED
+  if `global.metadata.env` is missing or doesn't match a key in the
+  map.
+
+The bundle version gate (`Chart.yaml` `version`, with `appVersion` as a
+fallback; major `>= 2`) and the catalog of mirrorable images
+(`global.bundle.<comp>.image` from the chart's own `values.yaml`) are
+read from `--chart` — the customer values file does not need to
+enumerate them.
+
+See [`examples/values-example.yaml`](examples/values-example.yaml) for the
+minimum shape of the values file.
+
+---
+
+## `dockerPullSecret` semantics
+
+When mirroring to a private registry, the cluster needs credentials to pull
+from your private registry. `kcli` enforces this explicitly — you must
+provide one of:
+
+| Flag                                 | When to use                                                         |
+|--------------------------------------|---------------------------------------------------------------------|
+| `--docker-pull-secret <base64>`      | You already have the secret material as a base64 blob.              |
+| `--docker-pull-secret-file <path>`   | You have a Docker `config.json` — the tool base64-encodes it.       |
+| `--no-pull-secret`                   | The cluster nodes have pre-configured access (e.g. IRSA, IAM, ECR). |
+
+Omitting all three flags is a hard error — this prevents leaving the
+values file in a state that silently fails at install time with
+`ImagePullBackOff`.
+
+The chosen secret is written into the values file under
+`global.dockerPullSecret` (or removed from it, with `--no-pull-secret`).
+
+---
+
+## What `kcli mirror` writes
+
+`kcli mirror` does not generate any new files in the chart directory.
+Instead, it edits the `--values` file you passed in **in place** and
+writes a timestamped backup of the original next to it:
+
+```
+my-values.yaml                       # ← rewritten in place
+my-values.yaml.bak.20260504T000015Z  # ← byte-for-byte copy of the
+                                     #   pre-rewrite original
+```
+
+The rewritten values file is what you pass to the chart install per the
+**Cortex Cloud portal** instructions for your tenant. To roll back, simply
+move the backup over the rewritten file:
+
+```bash
+mv my-values.yaml.bak.20260504T000015Z my-values.yaml
+```
+
+---
+
+## Environment variables
+
+| Variable                | Default     | Purpose                                                          |
+|-------------------------|-------------|------------------------------------------------------------------|
+| `NO_COLOR`              | _(unset)_   | Disable ANSI colors when set to a non-empty value                |
+| `DOCKER_CONFIG`         | `~/.docker` | Standard Docker config-dir override                              |
+| `TMPDIR`                | `/tmp`      | Override scratch directory                                       |
+| `KCLI_SKIP_VERSION_CHECK`| _(unset)_  | Bypass the mandatory upstream-version check (see [Staying current](#staying-current-mandatory-version-check)) |
+
+---
+
+## Exit codes
+
+| Code  | Meaning                                                                   |
+|-------|---------------------------------------------------------------------------|
+| `0`   | Success.                                                                  |
+| `1`   | Runtime failure (unsupported bundle version, push failures, missing prereq, …). |
+| `64`  | Usage error — bad flags, missing required arguments. (`EX_USAGE`.)        |
+| `65`  | Mandatory upstream-version check failed (local script is stale; see [Staying current](#staying-current-mandatory-version-check)). |
+| `130` | Interrupted by `SIGINT` / `SIGTERM`.                                      |
+
+---
+
+## Logging & diagnostics
+
+Each invocation writes a structured audit log to
+`$TMPDIR/kcli-log-XXXXXX.log`. The log is preserved across runs (success
+*and* failure) so you can always attach it to support tickets; on a
+non-zero exit its path is also surfaced in a `[WARN]` line.
+
+For verbose debugging, run with `bash -x`:
+
+```bash
+bash -x ./tools/kcli/kcli mirror …
+```
+
+---
+
+## Security notes
+
+- **No secrets are persisted by `kcli` itself.** The dockerPullSecret
+  material is held only in shell variables and the values file (which
+  lives where the operator chose to keep it). The audit log contains
+  only metadata, never credentials.
+- **Strict input validation.** Registry strings are bounded to a safe
+  character class (`[A-Za-z0-9._/:@-]`) and rejected outright if they
+  contain shell-injection-like sequences.
+- **Bundle gate.** Older / unrecognised bundle versions are rejected
+  before any registry traffic.
+- **Backup before mutation.** A timestamped `.bak` copy of the values
+  file is always written before the in-place rewrite — destructive edits
+  are reversible.
+- **Cleanup on failure.** `EXIT`, `INT`, and `TERM` traps remove
+  temporary scratch space even when interrupted. The values-file rewrite
+  is staged into a sibling temp file and committed via an atomic `mv`,
+  so on any failure the original file is left untouched and the
+  pre-rewrite `.bak` copy remains alongside it.
+
+---
+
+## License
+
+Licensed under the [Apache License, Version 2.0](LICENSE).

--- a/tools/kcli/examples/values-example.yaml
+++ b/tools/kcli/examples/values-example.yaml
@@ -1,0 +1,42 @@
+# ---------------------------------------------------------------------------
+# values-example.yaml — minimal customer values file for `kcli mirror`.
+#
+# `kcli mirror` reads exactly three fields from this file (and writes
+# the first two back at the end of the run, pointed at the private
+# registry):
+#
+#   * global.imageRegistry     — source registry / repo path used for
+#                                every container image in the bundle
+#   * global.dockerPullSecret  — base64 Docker config to authenticate
+#                                against the source registry
+#   * global.metadata.env      — deployment environment, used to
+#                                resolve per-env image tags from the
+#                                chart's .image.tagsByEnv.<env> map
+#                                (e.g. cortex-agent ships only via
+#                                tagsByEnv). Valid values:
+#                                  dev | prod | fr | gov
+#
+# Everything else (the bundle version gate and the list of mirrorable
+# images, including each image's name and tag) comes from the chart
+# archive passed via --chart — the customer values file stays minimal
+# by design.
+#
+# These three fields come from the values bundle issued for your
+# tenant via the Cortex Cloud portal — copy them as-is.
+# ---------------------------------------------------------------------------
+
+global:
+  # Container image registry for all bundle images. kcli reads the host
+  # portion (everything before the first '/') and uses it for `docker login`.
+  imageRegistry: "us-docker.pkg.dev/cortex-konnector/konnector"
+
+  # Base64-encoded Docker config.json used to authenticate against the
+  # source registry. The portal-issued values file already contains this.
+  dockerPullSecret: "<base64-encoded-docker-config-json>"
+
+  # Deployment environment. Used by kcli to pick the matching tag from
+  # any chart image that ships only via .image.tagsByEnv (e.g.
+  # cortex-agent: tagsByEnv.{dev,prod,fr,gov}). Components without a
+  # matching env entry are reported as SKIPPED.
+  metadata:
+    env: "prod"   # one of: dev | prod | fr | gov

--- a/tools/kcli/kcli
+++ b/tools/kcli/kcli
@@ -1,0 +1,1472 @@
+#!/usr/bin/env bash
+#
+# kcli — Cortex Cloud konnector CLI.
+#
+# A small, focused tool for operating the Palo Alto Networks Cortex Cloud
+# konnector Helm chart (bundle v2+) — currently centred on mirroring
+# container images from the source registry into a customer-controlled
+# private container registry, and rewriting the operator's values file
+# in place so it points the chart at the mirrored images.
+#
+# Subcommands:
+#   mirror   — pull bundle images from the source registry, push them to
+#              a private registry (preserving multi-arch manifests), and
+#              update the --values file in place (a .bak is written first).
+#   version  — print the kcli version.
+#   help     — show top-level help.
+#
+# Prerequisites: bash 4+, docker (with buildx), curl, jq, yq (mikefarah v4),
+#                tar, base64.
+#
+# Copyright (c) Palo Alto Networks. Licensed under Apache-2.0.
+
+set -Eeuo pipefail
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────────────────────────────────────
+readonly VERSION="1.0.0"
+readonly PROGRAM_NAME="kcli"
+
+# Minimum supported konnector bundle major version. The mirror flow relies
+# on the v2+ bundle layout (chart values declare per-component image
+# metadata under bundle.<comp>.image, gated via global.version >= 2).
+# Older bundles use a different layout and are not supported here.
+readonly MIN_BUNDLE_MAJOR=2
+
+# Where temporary scratch files live. Honor TMPDIR if set.
+readonly TMP_ROOT="${TMPDIR:-/tmp}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mandatory version-check configuration
+# ─────────────────────────────────────────────────────────────────────────────
+# kcli does not ship "release artifacts" — it is just a single script
+# committed at tools/kcli/kcli on the main branch. To make sure operators
+# always run the current logic, every invocation fetches the VERSION
+# constant from the canonical copy on GitHub and refuses to proceed
+# (with a clear remediation message) when the local script is stale.
+#
+# The check is best-effort: if curl is missing or the network is
+# unreachable we skip it silently rather than block legitimate work.
+# Set KCLI_SKIP_VERSION_CHECK=1 to bypass the check explicitly (e.g.
+# for air-gapped environments that vendor the script internally).
+readonly KCLI_GITHUB_RAW_URL="https://raw.githubusercontent.com/PaloAltoNetworks/cortex-cloud/main/tools/kcli/kcli"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Color & logging helpers
+# ─────────────────────────────────────────────────────────────────────────────
+# TTY-aware ANSI color output, honoring the NO_COLOR convention
+# (https://no-color.org/).
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+  RED=$'\033[0;31m'
+  GREEN=$'\033[0;32m'
+  YELLOW=$'\033[1;33m'
+  CYAN=$'\033[0;36m'
+  BOLD=$'\033[1m'
+  NC=$'\033[0m'
+else
+  RED='' ; GREEN='' ; YELLOW='' ; CYAN='' ; BOLD='' ; NC=''
+fi
+
+info()  { printf '%s[INFO]%s  %s\n' "$CYAN"   "$NC" "$*"; }
+ok()    { printf '%s[OK]%s    %s\n' "$GREEN"  "$NC" "$*"; }
+warn()  { printf '%s[WARN]%s  %s\n' "$YELLOW" "$NC" "$*"; }
+error() { printf '%s[ERROR]%s %s\n' "$RED"    "$NC" "$*" >&2; }
+
+# print_banner <title>
+# Prints a bold double-ruled banner around <title>.
+print_banner() {
+  local title="$1"
+  local rule="══════════════════════════════════════════════════════════════════════════════════"
+  echo ""
+  printf '%s╔%s╗%s\n' "$BOLD" "$rule" "$NC"
+  printf '%s║   %-78s ║%s\n' "$BOLD" "$title" "$NC"
+  printf '%s╚%s╝%s\n' "$BOLD" "$rule" "$NC"
+}
+
+# print_section <title>
+# Lightweight section header — single-rule banner.
+print_section() {
+  local title="$1"
+  local rule="──────────────────────────────────────────────────────────────────────────────────"
+  echo ""
+  printf '┌%s┐\n' "$rule"
+  printf '│ %-80s │\n' "$title"
+  printf '└%s┘\n' "$rule"
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Audit log + temp lifecycle
+# ─────────────────────────────────────────────────────────────────────────────
+# Run-scoped audit log path (set by init_log_file).
+LOG_FILE=""
+
+# Temp-file/dir registries — flushed on EXIT by cleanup().
+declare -a _TEMP_FILES=()
+declare -a _TEMP_DIRS=()
+
+register_temp_file() { _TEMP_FILES+=("$1"); }
+register_temp_dir()  { _TEMP_DIRS+=("$1"); }
+
+# init_log_file
+# Allocates an audit log under TMP_ROOT and prints its path. The log file
+# is intentionally NOT registered for cleanup — we preserve it on failure
+# so users can attach it to support tickets.
+init_log_file() {
+  # NOTE: BSD mktemp (macOS) only expands the trailing run of X's; if the
+  # template ends in a non-X suffix like ".log" the entire template is
+  # treated as a literal filename and the second invocation fails with
+  # "File exists". Use a pure-X suffix and rename to add the extension.
+  local _tmp
+  _tmp=$(mktemp "${TMP_ROOT}/${PROGRAM_NAME}-log-XXXXXX")
+  LOG_FILE="${_tmp}.log"
+  mv "$_tmp" "$LOG_FILE"
+  info "Log file: $LOG_FILE"
+}
+
+# log <message>
+# Appends a UTC-timestamped line to the audit log. Silently no-ops if the
+# log isn't initialised (so helpers can call log() unconditionally).
+log() {
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  if [[ -n "$LOG_FILE" && -w "$LOG_FILE" ]]; then
+    printf '[%s] %s\n' "$timestamp" "$*" >> "$LOG_FILE"
+  fi
+}
+
+# Cleanup invoked unconditionally on EXIT. Each rm is best-effort —
+# cleanup must never abort an otherwise-successful run.
+cleanup() {
+  local exit_code=$?
+  local f d
+  for f in "${_TEMP_FILES[@]:-}"; do
+    [[ -n "$f" && -f "$f" ]] && rm -f  "$f" 2>/dev/null || true
+  done
+  for d in "${_TEMP_DIRS[@]:-}"; do
+    [[ -n "$d" && -d "$d" ]] && rm -rf "$d" 2>/dev/null || true
+  done
+  if (( exit_code != 0 )) && [[ -n "$LOG_FILE" && -f "$LOG_FILE" ]]; then
+    warn "Non-zero exit ($exit_code). Log preserved at: $LOG_FILE"
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# Graceful shutdown on Ctrl-C / SIGTERM (exit 130 = 128 + SIGINT).
+on_signal() {
+  echo ""
+  warn "Caught signal — shutting down gracefully…"
+  log  "Caught signal — shutting down"
+  exit 130
+}
+trap on_signal INT TERM
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tiny utilities
+# ─────────────────────────────────────────────────────────────────────────────
+
+# base64_decode
+# Portable base64 decode that works on both BSD (macOS, -D) and GNU (-d).
+base64_decode() {
+  if base64 --help 2>&1 | grep -q -- '-D,'; then
+    base64 -D
+  else
+    base64 -d
+  fi
+}
+
+# is_yaml_file <path>
+# True if <path>'s extension is .yaml or .yml.
+is_yaml_file() {
+  case "$1" in
+    *.yaml|*.yml) return 0 ;;
+    *)            return 1 ;;
+  esac
+}
+
+# yq_or_empty <yq-expr> <file>
+# Like `yq <expr> <file>`, but emits an empty string instead of "null"
+# for missing keys, and never fails the script.
+yq_or_empty() {
+  local expr="$1" file="$2" value
+  value=$(yq "$expr" "$file" 2>/dev/null || true)
+  [[ "$value" == "null" ]] && value=""
+  printf '%s' "$value"
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Usage strings
+# ─────────────────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+${BOLD}${PROGRAM_NAME}${NC} v${VERSION} — Cortex konnector image-mirroring CLI
+
+${BOLD}Usage:${NC}
+  ${PROGRAM_NAME} <command> [options]
+
+${BOLD}Commands:${NC}
+  mirror     Pull bundle container images from the source registry and push
+             them to a private registry (preserving multi-arch manifests).
+             Updates the --values file in place to point at the mirror
+             (a timestamped .bak is written first).
+  version    Print the ${PROGRAM_NAME} version.
+  help       Show this help message.
+
+${BOLD}Global options:${NC}
+  -h, --help     Show this help message
+  -v, --version  Show ${PROGRAM_NAME} version
+
+${BOLD}Environment variables:${NC}
+  NO_COLOR                 Disable ANSI color output if set to a non-empty value
+  DOCKER_CONFIG            Standard Docker config-dir override (default: ~/.docker)
+  TMPDIR                   Override scratch directory (default: /tmp)
+  KCLI_SKIP_VERSION_CHECK  Bypass the mandatory upstream-version check
+                           (intended for air-gapped / vendored installs)
+
+${BOLD}Note:${NC} ${PROGRAM_NAME} requires the latest version. Each invocation
+verifies the local script against the canonical copy on GitHub
+(${KCLI_GITHUB_RAW_URL}) and refuses to run when stale.
+
+Run '${PROGRAM_NAME} <command> --help' for command-specific help.
+EOF
+}
+
+mirror_usage() {
+  cat <<EOF
+${BOLD}${PROGRAM_NAME} mirror${NC}
+
+Pull all bundle container images from the source registry and push them
+to a private registry, preserving multi-arch manifests.
+
+Workflow:
+  1. Extracts the chart archive (--chart) and reads:
+       - Chart.yaml      → bundle version (must be major >= ${MIN_BUNDLE_MAJOR})
+       - values.yaml     → global.bundle.<comp>.image entries (the
+                           authoritative list of mirrorable images)
+  2. Reads the source registry + credentials from --values:
+       - global.imageRegistry, global.dockerPullSecret
+  3. Pulls every bundle image (multi-arch, per-platform)
+  4. Pushes them to --private-registry via 'docker buildx imagetools create'
+  5. Rewrites the --values file in place — sets global.imageRegistry to the
+     private registry, optionally updates global.dockerPullSecret. A
+     timestamped .bak copy is written next to the file before any change.
+
+${BOLD}Usage:${NC}
+  ${PROGRAM_NAME} mirror --chart <chart.tgz> --values <values-file> \\
+                  --private-registry <registry> [options]
+
+${BOLD}Required:${NC}
+  --chart <chart.tgz>              Path to the konnector Helm chart archive
+                                   (the .tgz issued for your tenant)
+  --values <values-file>           Helm values YAML for your tenant.
+                                   See ${BOLD}VALUES FILE SCHEMA${NC} below for the
+                                   exact fields ${PROGRAM_NAME} reads and writes.
+  --private-registry <registry>    Target registry, e.g.
+                                   myregistry.azurecr.io/proj/repo
+
+${BOLD}Optional:${NC}
+  --docker-pull-secret <secret>    Base64-encoded dockerPullSecret for the
+                                   private registry (written into the
+                                   --values file under global.dockerPullSecret)
+  --docker-pull-secret-file <file> Path to a Docker config JSON for the
+                                   private registry (will be base64-encoded
+                                   and written as global.dockerPullSecret)
+  --no-pull-secret                 Strip global.dockerPullSecret from the
+                                   --values file (use only if the cluster
+                                   already has access)
+  --dry-run                        Show what would be done without pulling
+                                   or pushing images
+  -h, --help                       Show this help message
+
+${BOLD}VALUES FILE SCHEMA (--values):${NC}
+  The values file is the standard Helm values YAML issued for your tenant
+  via the Cortex Cloud portal. ${PROGRAM_NAME} only needs three keys from it.
+
+  ${BOLD}Read by ${PROGRAM_NAME}:${NC}
+    global.imageRegistry     ${YELLOW}(required)${NC} source registry / repo path,
+                             e.g. 'us-docker.pkg.dev/cortex-konnector/konnector'.
+                             The host portion is used for 'docker login'.
+    global.dockerPullSecret  ${YELLOW}(required for source pull)${NC} base64-encoded
+                             Docker config.json. The first auth entry's
+                             password is used as the GCP _json_key body
+                             to authenticate against the source registry.
+    global.metadata.env      ${YELLOW}(required for per-env images)${NC} deployment
+                             environment — one of: dev | prod | fr | gov.
+                             Used to resolve per-env image tags from the
+                             chart's .image.tagsByEnv.<env> map (e.g.
+                             cortex-agent ships only via tagsByEnv).
+                             Components without a static .image.tag and
+                             no matching env entry are SKIPPED.
+
+  ${BOLD}Sourced from --chart (not the values file):${NC}
+    Chart.yaml .version       Bundle version (gate: major must be >= ${MIN_BUNDLE_MAJOR}).
+    values.yaml .global.bundle The list of components to mirror, with
+                              per-component image name + tag (or
+                              tagsByEnv.<env>) + optional repository.
+
+  ${BOLD}Written by ${PROGRAM_NAME}:${NC}
+    global.imageRegistry     overwritten with --private-registry
+    global.bundle.<comp>.image.repository
+                             any per-component overrides already present
+                             are also rewritten to --private-registry
+                             (entries without an explicit 'repository'
+                             are left untouched — no key is injected)
+    global.dockerPullSecret  set from --docker-pull-secret[-file], OR
+                             removed when --no-pull-secret is passed
+
+  ${BOLD}Minimum example:${NC}
+    global:
+      imageRegistry: "us-docker.pkg.dev/cortex-konnector/konnector"
+      dockerPullSecret: "<base64-encoded-docker-config-json>"
+      metadata:
+        env: "prod"   # one of: dev | prod | fr | gov
+
+  A timestamped backup (<values-file>.bak.YYYYMMDDTHHMMSSZ) is always
+  written before the in-place rewrite. See examples/values-example.yaml
+  in the repo for a fully-commented template.
+
+${BOLD}Examples:${NC}
+  ${PROGRAM_NAME} mirror \\
+    --chart ./konnector-2.0.0.tgz \\
+    --values my-values.yaml \\
+    --private-registry myregistry.azurecr.io/cortex \\
+    --docker-pull-secret-file ~/.docker/config.json
+
+  ${PROGRAM_NAME} mirror \\
+    --chart ./konnector-2.0.0.tgz \\
+    --values my-values.yaml \\
+    --private-registry myregistry.azurecr.io/cortex \\
+    --dry-run
+EOF
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Top-level subcommand handlers
+# ─────────────────────────────────────────────────────────────────────────────
+
+cmd_version() { echo "${PROGRAM_NAME} v${VERSION}"; }
+cmd_help()    { usage; }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mandatory version check
+# ─────────────────────────────────────────────────────────────────────────────
+# kcli does not produce release artifacts — the canonical copy of this
+# script lives at tools/kcli/kcli on the main branch of the cortex-cloud
+# repository. To make sure operators always run the current logic, every
+# invocation parses the VERSION="x.y.z" constant out of the remote raw
+# file on GitHub and compares it to the local one. When the local
+# version is older we hard-fail with a remediation message.
+#
+# Best-effort caveats:
+#   - The check is skipped (with a warning) when curl is unavailable.
+#   - Any network / parse failure also skips the check (with a warning)
+#     so a transient outage cannot lock operators out of mirroring.
+#   - Setting KCLI_SKIP_VERSION_CHECK=1 disables the check entirely —
+#     intended for air-gapped environments that vendor the script.
+
+# kcli_remote_version
+# Fetches the canonical kcli script from main and extracts the value of
+# its `readonly VERSION="x.y.z"` declaration. Returns non-zero on any
+# fetch/parse failure (the caller decides what to do).
+kcli_remote_version() {
+  local remote_script remote_version
+  # 5-second timeout: keeps the user-perceived startup latency bounded
+  # even when GitHub is slow. The check fires once per invocation.
+  remote_script=$(curl -fsSL --max-time 5 "${KCLI_GITHUB_RAW_URL}" 2>/dev/null) || return 1
+  [[ -z "$remote_script" ]] && return 1
+
+  # Tolerate either single- or double-quoted VERSION declarations so a
+  # cosmetic upstream change (e.g. ' → ") cannot accidentally disable the
+  # mandatory version check.
+  remote_version=$(printf '%s\n' "$remote_script" \
+    | sed -nE 's/^readonly[[:space:]]+VERSION=["'"'"']([^"'"'"']+)["'"'"'].*/\1/p' \
+    | head -n1)
+  [[ -z "$remote_version" ]] && return 1
+  printf '%s\n' "$remote_version"
+}
+
+# kcli_version_compare <a> <b>
+# Three-way semver-ish comparator on dot-separated numeric versions.
+# Echoes -1 / 0 / 1 for a<b / a==b / a>b respectively. Non-numeric
+# segments are coerced to 0 so e.g. "1.0.0-dev" compares as "1.0.0".
+kcli_version_compare() {
+  local a="$1" b="$2"
+  # Strip any "-suffix" / "+meta" tail before splitting.
+  a="${a%%-*}"; a="${a%%+*}"
+  b="${b%%-*}"; b="${b%%+*}"
+
+  local IFS=.
+  # shellcheck disable=SC2206
+  local -a A=($a) B=($b)
+
+  local i max=${#A[@]}
+  (( ${#B[@]} > max )) && max=${#B[@]}
+
+  for (( i=0; i<max; i++ )); do
+    local av="${A[i]:-0}" bv="${B[i]:-0}"
+    # Coerce non-numeric to 0 — keeps the comparator total.
+    [[ "$av" =~ ^[0-9]+$ ]] || av=0
+    [[ "$bv" =~ ^[0-9]+$ ]] || bv=0
+    if   (( av < bv )); then printf -- '-1\n'; return 0
+    elif (( av > bv )); then printf  '1\n';   return 0
+    fi
+  done
+  printf '0\n'
+}
+
+# kcli_enforce_version <command-arg>
+# Mandatory pre-flight check invoked by main() before every subcommand
+# except help/version/empty. Fetches the upstream VERSION constant
+# from the main branch on GitHub and refuses to proceed (exit 65 —
+# EX_DATAERR-ish) when the local script is older.
+kcli_enforce_version() {
+  local command_arg="${1:-}"
+
+  # Always allow informational / no-op commands.
+  case "$command_arg" in
+    version|-v|--version|help|-h|--help|"") return 0 ;;
+  esac
+
+  # Operator escape hatch (air-gapped, internal vendoring, CI dry-runs).
+  if [[ -n "${KCLI_SKIP_VERSION_CHECK:-}" ]]; then
+    warn "KCLI_SKIP_VERSION_CHECK is set — skipping mandatory version check."
+    return 0
+  fi
+
+  # Without curl we cannot reach GitHub at all; warn but allow,
+  # otherwise we would lock out users on minimal images.
+  if ! command -v curl &>/dev/null; then
+    warn "curl not found — skipping version check (cannot verify ${PROGRAM_NAME} is current)."
+    return 0
+  fi
+
+  local remote
+  if ! remote=$(kcli_remote_version); then
+    warn "Could not reach ${KCLI_GITHUB_RAW_URL} to verify ${PROGRAM_NAME} version."
+    warn "Proceeding with local v${VERSION}; re-run with network access to confirm."
+    return 0
+  fi
+
+  local cmp
+  cmp=$(kcli_version_compare "${VERSION}" "${remote}")
+
+  case "$cmp" in
+    -1)
+      # Local is older than remote — block.
+      error "A newer ${PROGRAM_NAME} version is available."
+      error "  installed: v${VERSION}"
+      error "  upstream:  v${remote}"
+      error ""
+      error "${PROGRAM_NAME} requires the latest version. Update before retrying:"
+      error "  - If installed via 'git clone':  cd <repo> && git pull"
+      error "  - If installed by file copy:     re-fetch tools/kcli/kcli from"
+      error "      ${KCLI_GITHUB_RAW_URL}"
+      error ""
+      error "Set KCLI_SKIP_VERSION_CHECK=1 to bypass (air-gapped use only)."
+      exit 65
+      ;;
+    1)
+      # Local is *ahead* of remote — likely a development branch.
+      # Warn but proceed; operators on dev branches know what they're
+      # doing.
+      warn "Local ${PROGRAM_NAME} v${VERSION} is ahead of upstream v${remote} (development build?)."
+      ;;
+    0|*)
+      : # Up to date.
+      ;;
+  esac
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Prerequisite & input validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+# check_prerequisites <cmd…>
+# Verifies every named command is on PATH; aggregates missing names so the
+# user gets a single error listing everything they still need to install.
+check_prerequisites() {
+  local cmd
+  local -a missing=()
+
+  for cmd in "$@"; do
+    command -v "$cmd" &>/dev/null || missing+=("$cmd")
+  done
+
+  if (( ${#missing[@]} > 0 )); then
+    error "Missing required commands: ${missing[*]}"
+    error "Please install them and retry."
+    exit 1
+  fi
+}
+
+# require_arg <flag> <value>
+# Fails fast when a CLI flag is missing its operand (or the operand looks
+# like another flag). Use immediately after a `case "$1" in --foo)` arm.
+require_arg() {
+  local flag="$1" value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    error "$flag requires a value."
+    exit 1
+  fi
+}
+
+# validate_registry <registry>
+# Allow-lists registry strings to a safe character class, and rejects
+# obvious shell-injection patterns (.., ;, |, &). Examples accepted:
+#   myregistry.azurecr.io/proj/repo
+#   gcr.io/project
+#   localhost:5000/test
+validate_registry() {
+  local registry="$1"
+
+  if [[ -z "$registry" ]]; then
+    error "Registry value cannot be empty."
+    exit 1
+  fi
+
+  if [[ ! "$registry" =~ ^[a-zA-Z0-9._/:@-]+$ ]]; then
+    error "Invalid registry value: '$registry'"
+    error "Allowed characters: alphanumeric, dot, dash, underscore, slash, colon, '@'."
+    exit 1
+  fi
+
+  if [[ "$registry" == *".."* || "$registry" == *";"* \
+        || "$registry" == *"|"*  || "$registry" == *"&"* ]]; then
+    error "Invalid registry value: '$registry' — contains suspicious characters."
+    exit 1
+  fi
+
+  log "Registry validated: $registry"
+}
+
+# parse_major_version <version-string>
+# Extracts the integer major-version component from a string such as
+# "2.1.0", "v2.1.0-rc1", or "v3". Echoes the integer on success;
+# returns non-zero (with empty stdout) on failure.
+#
+# Mirrors the helper of the same name in PaloAltoNetworks/ktool's
+# kubectl-ktool.sh — a leading 'v' is optional and any trailing
+# pre-release/build metadata is ignored.
+parse_major_version() {
+  local release_string="$1"
+  if [[ "$release_string" =~ ^v?([0-9]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+# check_bundle_version <chart-yaml>
+# Verifies the chart advertises a supported konnector bundle version.
+#
+# The bundle's real version lives in the chart's Chart.yaml. We prefer
+# .version (Helm guarantees it is valid SemVer-2 — reliable for the
+# numeric major-version gate) and fall back to .appVersion (which Helm
+# allows to be any string) when .version is missing. The chart's
+# values.yaml only carries a placeholder default ('0.0.0') and is NOT
+# consulted.
+check_bundle_version() {
+  local chart_yaml="$1"
+  local bundle_version major
+
+  bundle_version=$(yq_or_empty '.version' "$chart_yaml")
+  if [[ -z "$bundle_version" ]]; then
+    bundle_version=$(yq_or_empty '.appVersion' "$chart_yaml")
+  fi
+
+  if [[ -z "$bundle_version" ]]; then
+    error "Unsupported bundle: chart Chart.yaml has no 'version' or 'appVersion' entry."
+    error "The mirror flow requires konnector bundle v${MIN_BUNDLE_MAJOR} or higher."
+    error "Please obtain a v${MIN_BUNDLE_MAJOR}+ bundle from the Cortex backend and retry."
+    exit 1
+  fi
+
+  major=$(parse_major_version "$bundle_version") || {
+    error "Unsupported bundle: cannot parse chart version = '$bundle_version'."
+    error "The mirror flow requires konnector bundle v${MIN_BUNDLE_MAJOR} or higher."
+    exit 1
+  }
+
+  if (( major < MIN_BUNDLE_MAJOR )); then
+    error "Unsupported bundle version: chart version = '$bundle_version' (major=$major)."
+    error "The mirror flow requires konnector bundle v${MIN_BUNDLE_MAJOR} or higher."
+    error "Please upgrade to a v${MIN_BUNDLE_MAJOR}+ bundle and retry."
+    exit 1
+  fi
+
+  ok  "Bundle version: $bundle_version (meets v${MIN_BUNDLE_MAJOR}+ requirement)"
+  log "Bundle version: $bundle_version (major=$major)"
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pull/push summary table
+# ─────────────────────────────────────────────────────────────────────────────
+# A single tabular renderer, reused for the "pulled" and "pushed" reports.
+# Records are stored in a pipe-delimited file with the schema:
+#     STATUS|COMPONENT|IMAGE|TAG|ARCHS|NOTE
+#
+# print_summary_table <title> <summary-file> <ok-label>
+# Sets globals: total_ok, total_fail, total_skip
+print_summary_table() {
+  local title="$1" summary_file="$2" ok_label="$3"
+
+  print_section "$title"
+
+  printf "  %s%-20s %-35s %-12s %-6s %-20s%s\n" "$CYAN" \
+    "COMPONENT" "IMAGE" "TAG" "STATUS" "ARCHITECTURES" "$NC"
+  printf "  %-20s %-35s %-12s %-6s %-20s\n" \
+    "────────────────────" "───────────────────────────────────" \
+    "────────────" "──────" "────────────────────"
+
+  total_ok=0; total_fail=0; total_skip=0
+
+  if [[ -f "$summary_file" ]]; then
+    local status component img_name img_tag archs _note icon
+    while IFS='|' read -r status component img_name img_tag archs _note; do
+      case "$status" in
+        OK)      icon="${GREEN}✓${NC}";  total_ok=$((total_ok + 1)) ;;
+        FAILED)  icon="${RED}✗${NC}";    total_fail=$((total_fail + 1)) ;;
+        SKIPPED) icon="${YELLOW}⊘${NC}"; total_skip=$((total_skip + 1)) ;;
+        *)       icon="?" ;;
+      esac
+      printf "  %-20s %-35s %-12s " "$component" "$img_name" "$img_tag"
+      printf '%b      %s\n' "$icon" "$archs"
+    done < "$summary_file"
+  fi
+
+  echo ""
+  printf "  %s%s:%s  %d    %sFailed:%s  %d    %sSkipped:%s  %d\n" \
+    "$GREEN"  "$ok_label" "$NC" "$total_ok" \
+    "$RED"    "$NC" "$total_fail" \
+    "$YELLOW" "$NC" "$total_skip"
+  echo ""
+
+  log "${title}: ${ok_label}=${total_ok} Failed=${total_fail} Skipped=${total_skip}"
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Source-registry credentials & login
+# ─────────────────────────────────────────────────────────────────────────────
+# Globals populated by extract_credentials_from_values:
+#   image_repository  — the source registry/repo path (e.g. gcr.io/proj/sub)
+#   registry_host     — just the host portion (gcr.io)
+#   project_path      — everything after the host (proj/sub)
+#   sa_json_key       — the GCP service-account JSON key (used to login)
+
+image_repository=""
+registry_host=""
+project_path=""
+sa_json_key=""
+
+# extract_credentials_from_values <values-file>
+# Reads image.repository and dockerPullSecret out of the customer values
+# file. The dockerPullSecret is a base64'd Docker config.json — we decode
+# it and grab the first auth entry's password (which is the GCP
+# _json_key body for the source registry).
+extract_credentials_from_values() {
+  local values_source="$1"
+
+  # In bundle v2+ all customer-tunable values live under .global.*, so
+  # both imageRegistry (the source registry/repo path used for every
+  # bundle image) and dockerPullSecret are read from there.
+  info "Extracting global.imageRegistry from values…"
+  image_repository=$(yq_or_empty '.global.imageRegistry' "$values_source")
+  if [[ -z "$image_repository" ]]; then
+    error "Could not extract 'global.imageRegistry' from values."
+    error "Bundle v${MIN_BUNDLE_MAJOR}+ stores the source registry under 'global.imageRegistry'."
+    exit 1
+  fi
+  ok "global.imageRegistry = $image_repository"
+
+  registry_host="${image_repository%%/*}"               # everything before the first slash
+  project_path="${image_repository#"$registry_host"/}"  # everything after
+
+  info "Registry host: $registry_host"
+  info "Project path:  $project_path"
+
+  info "Extracting global.dockerPullSecret from values…"
+  local docker_pull_secret
+  docker_pull_secret=$(yq_or_empty '.global.dockerPullSecret' "$values_source")
+
+  # Fallback for values files where yq fails (very long single-line literals
+  # that some YAML emitters wrap awkwardly). Match indented form too.
+  if [[ -z "$docker_pull_secret" ]]; then
+    docker_pull_secret=$(grep -E '^[[:space:]]*dockerPullSecret:[[:space:]]*' \
+        "$values_source" 2>/dev/null \
+      | sed 's/^[[:space:]]*dockerPullSecret:[[:space:]]*//' \
+      | tr -d '"' || true)
+  fi
+
+  if [[ -z "$docker_pull_secret" ]]; then
+    warn "Could not extract 'dockerPullSecret' from values. Source registry login will be skipped."
+    sa_json_key=""
+    return
+  fi
+  ok "dockerPullSecret extracted."
+
+  sa_json_key=$(echo "$docker_pull_secret" | base64_decode 2>/dev/null \
+    | jq -r '.auths | to_entries[0].value.password' 2>/dev/null || echo "")
+
+  if [[ -z "$sa_json_key" || "$sa_json_key" == "null" ]]; then
+    warn "Failed to decode service-account key from dockerPullSecret."
+    sa_json_key=""
+    return
+  fi
+  ok "Service-account JSON key decoded."
+}
+
+# login_to_source_registry
+# Logs into the source registry as _json_key using the decoded key.
+# Failures are warnings (not fatal) — some images may still be pullable
+# anonymously, and the per-image pull loop reports its own outcome.
+login_to_source_registry() {
+  if [[ -z "$sa_json_key" ]]; then
+    warn "No service-account key available — skipping source registry login."
+    return
+  fi
+
+  info "Logging in to source registry: $registry_host …"
+
+  if echo "$sa_json_key" | docker login "$registry_host" \
+       --username _json_key --password-stdin >/dev/null 2>&1; then
+    ok "Docker registry login successful."
+  else
+    warn "Docker login to $registry_host failed. Image pulls may fail."
+  fi
+}
+
+# ensure_target_registry_login <target-host>
+# Fast-paths when credentials are already in the Docker config; otherwise
+# triggers an interactive `docker login`. Skipped entirely in dry-run
+# mode by the caller. Exits 1 if the interactive login fails.
+ensure_target_registry_login() {
+  local target_host="$1"
+  local docker_config="${DOCKER_CONFIG:-$HOME/.docker}"
+
+  info "Checking Docker login to target registry: $target_host …"
+
+  if [[ -f "$docker_config/config.json" ]] \
+     && jq -e --arg host "$target_host" \
+          '.auths[$host] // .auths["https://" + $host] // empty' \
+          "$docker_config/config.json" >/dev/null 2>&1; then
+    ok "Already logged in to $target_host (credentials found in Docker config)."
+    return
+  fi
+
+  warn "No existing credentials found for $target_host."
+  info "Attempting interactive Docker login to $target_host …"
+  echo ""
+  if docker login "$target_host"; then
+    ok "Successfully logged in to $target_host."
+  else
+    error "Docker login to $target_host failed."
+    error "Please run 'docker login $target_host' manually and retry."
+    exit 1
+  fi
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Image enumeration & multi-arch pull/push
+# ─────────────────────────────────────────────────────────────────────────────
+
+# build_bundle_image_list <chart-values-yaml> <values-yaml>
+# Enumerates every mirrorable image declared by the chart under
+# .global.bundle.<comp>.image. The chart is the single source of truth
+# for the bundle LAYOUT (component list, image name, default tag); the
+# customer values file is consulted ONLY for .global.metadata.env so we
+# can resolve per-env image tags (.image.tagsByEnv.<env>).
+#
+# Tag resolution per component, in order:
+#   1. .image.tag
+#   2. .image.tagsByEnv[<global.metadata.env from --values>]
+#   3. empty string  → component is reported as SKIPPED (no tag)
+#
+# A component appears in the output iff the chart defines a non-empty
+# .image.name. Echoes a JSON array of {component, name, tag, repository}.
+build_bundle_image_list() {
+  local chart_values_yaml="$1" values_yaml="$2"
+  local chart_values_json env
+
+  chart_values_json=$(yq -o=json '.' "$chart_values_yaml")
+  env=$(yq_or_empty '.global.metadata.env' "$values_yaml")
+
+  jq -n \
+    --argjson chart "$chart_values_json" \
+    --arg     env   "$env" \
+    '
+    [
+      ($chart.global.bundle // {}) | to_entries[] |
+      .key as $comp |
+      (.value.image // {}) as $img |
+      select($img.name != null and $img.name != "") |
+      # Resolve the effective tag: prefer .tag, fall back to
+      # .tagsByEnv[$env] when --values provides a non-empty
+      # global.metadata.env. An empty result downstream becomes
+      # SKIPPED with a clear "no tag specified" reason.
+      ((($img.tag // "")
+        | if . == "" and ($env != "") and ($img.tagsByEnv | type == "object")
+            then ($img.tagsByEnv[$env] // "")
+          else .
+          end) // "") as $effective_tag |
+      {
+        component:  $comp,
+        name:       $img.name,
+        tag:        $effective_tag,
+        repository: ($img.repository // "")
+      }
+    ]'
+}
+
+# fetch_raw_manifest <full-image>
+# Echoes the raw multi-arch manifest list (image index) JSON for a
+# remote image, or empty on any failure. Prefers `docker buildx
+# imagetools inspect --raw` because it reliably returns the full
+# manifest list across ALL platforms — `docker manifest inspect` on
+# Docker Desktop / macOS sometimes filters results to just the client
+# platform, which would silently turn multi-arch sources into
+# "single-arch only" mirrors.
+fetch_raw_manifest() {
+  local full_image="$1"
+  local out
+  if out=$(docker buildx imagetools inspect --raw "$full_image" 2>/dev/null) && [[ -n "$out" ]]; then
+    printf '%s' "$out"
+    return 0
+  fi
+  # Fallback for environments without buildx imagetools (older Docker).
+  docker manifest inspect "$full_image" 2>/dev/null || true
+}
+
+# inspect_manifest_archs <full-image>
+# Echoes a comma-separated list of linux architectures present in the
+# remote manifest (or "single-arch" / "platform info unavailable").
+inspect_manifest_archs() {
+  local full_image="$1"
+  fetch_raw_manifest "$full_image" \
+    | jq -r '
+        if .manifests then
+          [.manifests[]
+            | select((.platform.os == "linux") and (.platform.architecture // "") != "unknown")
+            | .platform.architecture]
+            | unique | join(", ")
+        else
+          "single-arch"
+        end' 2>/dev/null \
+    || echo "platform info unavailable"
+}
+
+# inspect_manifest_platforms <full-image>
+# Echoes one "linux/<arch>" platform per line for use with
+# `docker pull --platform`. Empty output for single-arch images.
+inspect_manifest_platforms() {
+  local full_image="$1"
+  fetch_raw_manifest "$full_image" \
+    | jq -r '
+        if .manifests then
+          [.manifests[]
+            | select((.platform.os == "linux") and (.platform.architecture // "") != "unknown")
+            | "\(.platform.os)/\(.platform.architecture)"]
+            | unique | .[]
+        else
+          empty
+        end' 2>/dev/null \
+    || true
+}
+
+# pull_image_multiarch <component> <full-image> → echoes "<archs>|<status>"
+#   archs   : comma-separated arch list, "single-arch", "N/A", or
+#             "platform info unavailable"
+#   status  : "OK" | "SKIPPED:<reason>"
+# Returns 0 on OK, 1 on SKIPPED.
+#
+# IMPORTANT: This function's stdout is captured by the caller (the only
+# thing it should print to stdout is the final "<archs>|<status>" line).
+# All progress logging therefore goes through info/ok/warn redirected
+# to STDERR so it never pollutes the captured value.
+pull_image_multiarch() {
+  local component="$1" full_image="$2"
+  local manifest_json archs platforms pull_ok=false
+
+  manifest_json=$(fetch_raw_manifest "$full_image")
+
+  # No manifest available — fall back to a best-effort single-arch pull.
+  if [[ -z "$manifest_json" ]]; then
+    if docker pull "$full_image" >/dev/null 2>&1; then
+      archs=$(docker inspect "$full_image" 2>/dev/null \
+        | jq -r '.[0].Architecture // "platform info unavailable"' 2>/dev/null \
+        || echo "platform info unavailable")
+      printf '%s|OK\n' "$archs"
+      return 0
+    fi
+    printf 'N/A|SKIPPED:image not found in registry\n'
+    return 1
+  fi
+
+  archs=$(inspect_manifest_archs "$full_image")
+  platforms=$(inspect_manifest_platforms "$full_image")
+
+  if [[ -n "$platforms" ]]; then
+    local platform
+    while read -r platform; do
+      [[ -z "$platform" ]] && continue
+      info "[$component]   pulling platform: $platform" >&2
+      if docker pull --platform "$platform" "$full_image" >/dev/null 2>&1; then
+        ok   "[$component]   ✓ $platform"                >&2
+      else
+        warn "[$component]   ✗ $platform (pull failed, skipping)" >&2
+      fi
+    done <<< "$platforms"
+
+    # We pushed via 'docker buildx imagetools create' which works
+    # straight off the remote registry, so a successful per-platform
+    # pull cycle counts as OK regardless of local cache state.
+    pull_ok=true
+  else
+    docker pull "$full_image" >/dev/null 2>&1 && pull_ok=true
+  fi
+
+  if [[ "$pull_ok" == "true" ]]; then
+    printf '%s|OK\n' "$archs"
+    return 0
+  fi
+  printf '%s|SKIPPED:pull failed\n' "${archs:-N/A}"
+  return 1
+}
+
+# push_image_multiarch <src> <dst>
+# Tries multi-arch copy via `docker buildx imagetools create`; falls back
+# to `docker tag` + `docker push` on failure. Echoes a short note on
+# stdout and returns 0/1.
+push_image_multiarch() {
+  local src="$1" dst="$2"
+
+  if docker buildx imagetools create --tag "$dst" "$src" >/dev/null 2>&1; then
+    echo "OK"
+    return 0
+  fi
+
+  warn "  buildx imagetools failed, attempting docker tag+push fallback…"
+  if docker tag "$src" "$dst" >/dev/null 2>&1 \
+     && docker push "$dst" >/dev/null 2>&1; then
+    echo "single-arch fallback"
+    return 0
+  fi
+
+  echo "push failed"
+  return 1
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-image pull/push iteration helpers (one record at a time)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# process_pull_record <img_entry_json> <dry_run> <summary_file>
+# Pulls one image (or simulates it under dry-run) and appends a status
+# record to <summary_file>.
+process_pull_record() {
+  local img_entry="$1" dry_run="$2" summary_file="$3"
+
+  local component img_name img_tag img_repo effective_repo full_image
+  component=$(jq -r '.component'  <<<"$img_entry")
+  img_name=$( jq -r '.name'       <<<"$img_entry")
+  img_tag=$(  jq -r '.tag'        <<<"$img_entry")
+  img_repo=$( jq -r '.repository' <<<"$img_entry")
+
+  if [[ -z "$img_tag" ]]; then
+    warn "[$component] Skipping '$img_name' — no tag specified in chart values."
+    printf 'SKIPPED|%s|%s|%s|N/A|no tag specified\n' \
+      "$component" "$img_name" "$img_tag" >> "$summary_file"
+    return
+  fi
+
+  effective_repo="${img_repo:-$image_repository}"
+  full_image="${effective_repo}/${img_name}:${img_tag}"
+
+  if [[ "$dry_run" == "true" ]]; then
+    info "[$component] [DRY RUN] Would pull: $full_image"
+    printf 'OK|%s|%s|%s|dry-run|\n' \
+      "$component" "$img_name" "$img_tag" >> "$summary_file"
+    echo ""
+    return
+  fi
+
+  info "[$component] Pulling (multi-arch): $full_image"
+
+  local result archs note
+  if result=$(pull_image_multiarch "$component" "$full_image"); then
+    # Defensive: collapse any embedded newlines in archs so a stray
+    # stdout line from a helper can never corrupt the summary table.
+    archs=$(printf '%s' "${result%%|*}" | tr -d '\n\r')
+    ok "[$component] Successfully pulled: $full_image"
+    printf 'OK|%s|%s|%s|%s|\n' \
+      "$component" "$img_name" "$img_tag" "$archs" >> "$summary_file"
+  else
+    archs=$(printf '%s' "${result%%|*}" | tr -d '\n\r')
+    note="${result#*|}"
+    note="${note#SKIPPED:}"
+    note=$(printf '%s' "$note" | tr -d '\n\r')
+    warn "[$component] Skipped: $note ($full_image)"
+    printf 'SKIPPED|%s|%s|%s|%s|%s\n' \
+      "$component" "$img_name" "$img_tag" "$archs" "$note" >> "$summary_file"
+  fi
+  echo ""
+}
+
+# process_push_record <pull_record> <push_target> <dry_run> <summary_file>
+# Reads one pull record (pipe-delimited line) and pushes the corresponding
+# image to <push_target>, appending a status record to <summary_file>.
+process_push_record() {
+  local pull_record="$1" push_target="$2" dry_run="$3" summary_file="$4"
+
+  local status component img_name img_tag archs _note
+  IFS='|' read -r status component img_name img_tag archs _note <<<"$pull_record"
+
+  if [[ "$status" != "OK" ]]; then
+    printf 'SKIPPED|%s|%s|%s|%s|not pulled\n' \
+      "$component" "$img_name" "$img_tag" "$archs" >> "$summary_file"
+    return
+  fi
+
+  local src="${image_repository}/${img_name}:${img_tag}"
+  local dst="${push_target}/${img_name}:${img_tag}"
+
+  if [[ "$dry_run" == "true" ]]; then
+    info "[$component] [DRY RUN] Would push: $src → $dst"
+    printf 'OK|%s|%s|%s|%s|dry-run\n' \
+      "$component" "$img_name" "$img_tag" "$archs" >> "$summary_file"
+    echo ""
+    return
+  fi
+
+  info "[$component] Copying: $src → $dst"
+  local note
+  if note=$(push_image_multiarch "$src" "$dst"); then
+    ok "[$component] Successfully pushed: $dst (${note})"
+    if [[ "$note" == "single-arch fallback" ]]; then
+      printf 'OK|%s|%s|%s|%s|single-arch fallback\n' \
+        "$component" "$img_name" "$img_tag" "$archs" >> "$summary_file"
+    else
+      printf 'OK|%s|%s|%s|%s|\n' \
+        "$component" "$img_name" "$img_tag" "$archs" >> "$summary_file"
+    fi
+  else
+    error "[$component] Failed to push: $dst"
+    printf 'FAILED|%s|%s|%s|%s|push failed\n' \
+      "$component" "$img_name" "$img_tag" "$archs" >> "$summary_file"
+  fi
+  echo ""
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# In-place values-file rewrite
+# ─────────────────────────────────────────────────────────────────────────────
+
+# rewrite_values_in_place <values_file> <push_target> <secret> <no_pull_secret>
+# Rewrites the operator's values file IN PLACE so it points the konnector
+# chart at the mirrored registry:
+#   * Always sets global.imageRegistry = <push_target>.
+#   * Also rewrites any per-component global.bundle.<comp>.image.repository
+#     overrides that already exist.
+#   * Sets   global.dockerPullSecret iff <secret> is non-empty.
+#   * Removes global.dockerPullSecret iff <no_pull_secret> == "true".
+#
+# A timestamped backup is written next to the file as
+# <values_file>.bak.<UTC-timestamp> before any mutation, so the operator
+# always has a way to undo the change.
+rewrite_values_in_place() {
+  local values_file="$1"
+  local push_target="$2"
+  local docker_pull_secret_override="$3"
+  local no_pull_secret="$4"
+
+  local backup_path
+  backup_path="${values_file}.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+  cp "$values_file" "$backup_path"
+  ok "Backup of original values file: $backup_path"
+  log "Backup created: $backup_path"
+
+  # Build the jq filter for bundle v2+ values:
+  #   * Always rewrite global.imageRegistry (single source-of-truth used
+  #     by the chart for every image's effective repository).
+  #   * Also rewrite any per-component global.bundle.<comp>.image.repository
+  #     overrides — the chart honors them when present, so they need to
+  #     point at the mirror as well.
+  #   * Inject  global.dockerPullSecret iff the operator provided one.
+  #   * Strip   global.dockerPullSecret iff --no-pull-secret was passed.
+  # NOTE: $target / $secret below are jq variables (passed via --arg),
+  # not bash variables — single quotes here are intentional.
+  # shellcheck disable=SC2016
+  local jq_filter='(.global.imageRegistry = $target) | (.global.bundle |= (if . then with_entries(if .value.image.repository? then .value.image.repository = $target else . end) else . end))'
+  local -a jq_args=(--arg target "$push_target")
+
+  if [[ -n "$docker_pull_secret_override" ]]; then
+    jq_filter="${jq_filter} | (.global.dockerPullSecret = \$secret)"
+    jq_args+=(--arg secret "$docker_pull_secret_override")
+    info "global.dockerPullSecret will be set in $values_file"
+  elif [[ "$no_pull_secret" == "true" ]]; then
+    jq_filter="${jq_filter} | del(.global.dockerPullSecret)"
+    info "global.dockerPullSecret will be removed from $values_file (--no-pull-secret)"
+  fi
+
+  # Round-trip via jq so we get a deterministic transformation, then
+  # write through a temp file in the same directory (atomic mv on the
+  # same filesystem). yq -P preserves YAML formatting on the way out.
+  local tmp_out
+  tmp_out=$(mktemp "${values_file}.kcli-XXXXXX")
+  register_temp_file "$tmp_out"
+
+  if ! yq -o=json '.' "$values_file" \
+       | jq "${jq_args[@]}" "$jq_filter" \
+       | yq -P > "$tmp_out"; then
+    error "Failed to rewrite values file. Original is unchanged; backup preserved at: $backup_path"
+    exit 1
+  fi
+
+  mv "$tmp_out" "$values_file"
+  ok "Updated values file in place: $values_file"
+  log "In-place rewrite complete: $values_file"
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Final summary block printed at the end of `mirror`
+# ─────────────────────────────────────────────────────────────────────────────
+
+# print_completion_summary <chart_tgz> <values_file>
+# Lists the artifacts the operator should hand to the install flow and
+# points them at the Cortex Cloud portal for the canonical install
+# instructions. We deliberately do NOT echo a `helm install` command (or
+# namespace/release-name guidance) — the official portal flow is the
+# single source of truth.
+print_completion_summary() {
+  local chart_tgz="$1" values_file="$2"
+
+  print_banner "MIRROR COMPLETE"
+  echo ""
+  printf "  %sArtifacts:%s\n" "$CYAN" "$NC"
+  printf "    📦 Chart:           %s%s%s\n" "$GREEN" "$chart_tgz"   "$NC"
+  printf "    📄 Values (edited): %s%s%s\n" "$GREEN" "$values_file" "$NC"
+  echo ""
+  printf "  %sNext step:%s\n" "$CYAN" "$NC"
+  echo  "    Install the konnector chart using the artifacts above by following"
+  echo  "    the installation instructions for your tenant in the Cortex Cloud portal."
+  echo ""
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# cmd_mirror — the `mirror` subcommand orchestrator
+# ─────────────────────────────────────────────────────────────────────────────
+# This function reads cleanly top-to-bottom:
+#   1. parse + validate flags
+#   2. enforce dockerPullSecret semantics
+#   3. check prerequisites
+#   4. extract & validate chart values (including bundle-version gate)
+#   5. login to source + pull every bundle image
+#   6. login to target + push every pulled image
+#   7. rewrite the --values file in place (with .bak)
+#   8. print final summary
+#
+# Heavy lifting is delegated to single-purpose helpers above.
+cmd_mirror() {
+  # ─── 1. Parse arguments ────────────────────────────────────────────────
+  local chart_tgz_file="" values_file="" push_target=""
+  local docker_pull_secret_override=""
+  local no_pull_secret=false
+  local dry_run=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --chart)
+        require_arg "--chart" "${2:-}"
+        chart_tgz_file="$2"; shift 2
+        ;;
+      --values)
+        require_arg "--values" "${2:-}"
+        values_file="$2"; shift 2
+        ;;
+      --private-registry)
+        require_arg "--private-registry" "${2:-}"
+        push_target="$2"; shift 2
+        ;;
+      --docker-pull-secret)
+        require_arg "--docker-pull-secret" "${2:-}"
+        docker_pull_secret_override="$2"; shift 2
+        ;;
+      --docker-pull-secret-file)
+        require_arg "--docker-pull-secret-file" "${2:-}"
+        if [[ ! -f "$2" ]]; then
+          error "Docker pull secret file not found: $2"
+          exit 1
+        fi
+        # base64 without line wraps → stable single-line value.
+        docker_pull_secret_override=$(base64 < "$2" 2>/dev/null | tr -d '\n')
+        if [[ -z "$docker_pull_secret_override" ]]; then
+          error "Failed to base64-encode the docker pull secret file: $2"
+          exit 1
+        fi
+        info "Docker pull secret loaded from file: $2"
+        shift 2
+        ;;
+      --no-pull-secret) no_pull_secret=true; shift ;;
+      --dry-run)        dry_run=true;        shift ;;
+      -h|--help)        mirror_usage;        exit 0 ;;
+      *)
+        error "Unknown argument for 'mirror': $1"
+        echo ""
+        mirror_usage
+        exit 64
+        ;;
+    esac
+  done
+
+  # ─── 2. Validate required arguments ───────────────────────────────────
+  [[ -z "$chart_tgz_file" ]] && { error "Missing required flag: --chart <chart.tgz>";          echo ""; mirror_usage; exit 64; }
+  [[ -z "$values_file"    ]] && { error "Missing required flag: --values <values-file>";       echo ""; mirror_usage; exit 64; }
+  [[ -z "$push_target"    ]] && { error "Missing required flag: --private-registry <registry>"; echo ""; mirror_usage; exit 64; }
+
+  if [[ ! -f "$chart_tgz_file" ]]; then error "Chart archive not found: $chart_tgz_file"; exit 1; fi
+  if [[ ! -f "$values_file"    ]]; then error "Values file not found: $values_file";      exit 1; fi
+
+  case "$chart_tgz_file" in
+    *.tgz|*.tar.gz) : ;;
+    *)
+      error "--chart must point to a .tgz or .tar.gz Helm chart archive: $chart_tgz_file"
+      exit 1
+      ;;
+  esac
+
+  validate_registry "$push_target"
+
+  # Mirroring without a pull-secret strategy is almost never what the user
+  # wants — fail loudly unless they explicitly opted out.
+  if [[ -z "$docker_pull_secret_override" && "$no_pull_secret" != "true" ]]; then
+    error "A dockerPullSecret is required when mirroring to a private registry."
+    error "The Kubernetes cluster needs this secret to pull images from your private registry."
+    echo ""
+    error "Provide one of:"
+    error "  --docker-pull-secret <base64-encoded-secret>"
+    error "  --docker-pull-secret-file <path-to-docker-config.json>"
+    echo ""
+    error "If your cluster already has pre-configured access, use:"
+    error "  --no-pull-secret"
+    exit 1
+  fi
+
+  # ─── 3. Check prerequisites ───────────────────────────────────────────
+  check_prerequisites docker base64 yq jq curl tar
+  if ! docker buildx version &>/dev/null; then
+    error "'docker buildx' is required for pushing multi-arch manifests."
+    error "Install it: https://docs.docker.com/buildx/install/"
+    exit 1
+  fi
+
+  # ─── 4. Init logging + banner ─────────────────────────────────────────
+  init_log_file
+  log "Chart:       $chart_tgz_file"
+  log "Values file: $values_file"
+  log "Push target: $push_target"
+  log "Dry run:     $dry_run"
+
+  print_banner "${PROGRAM_NAME} — image mirror"
+  info "Chart:         $chart_tgz_file"
+  info "Push target:   $push_target"
+  info "Values file:   $values_file"
+  if [[ "$dry_run" == "true" ]]; then
+    info "Mode:          DRY RUN (no images will be pulled or pushed)"
+  fi
+  echo ""
+
+  # ─── 5. Source-registry credentials & login ──────────────────────────
+  info "Step 1/3: Extracting credentials and logging in to source registry…"
+  extract_credentials_from_values "$values_file"
+  login_to_source_registry
+
+  # ─── 6. Build image list & pull ──────────────────────────────────────
+  info "Step 2/3: Pulling bundle images…"
+
+  local chart_extract_dir chart_values_yaml chart_yaml
+  chart_extract_dir=$(mktemp -d "${TMP_ROOT}/${PROGRAM_NAME}-chart-values-XXXXXX")
+  register_temp_dir "$chart_extract_dir"
+  if ! tar -xzf "$chart_tgz_file" -C "$chart_extract_dir" 2>/dev/null; then
+    error "Failed to extract chart archive: $chart_tgz_file"
+    exit 1
+  fi
+
+  # Top-level Chart.yaml — the umbrella chart's metadata. Its .version
+  # is the canonical bundle release identifier we gate on (Helm guarantees
+  # it's valid SemVer-2 — reliable for numeric comparison).
+  chart_yaml=$(find "$chart_extract_dir" -mindepth 2 -maxdepth 2 -name 'Chart.yaml' -print 2>/dev/null | head -1)
+  if [[ -z "$chart_yaml" || ! -f "$chart_yaml" ]]; then
+    error "Could not locate Chart.yaml in chart archive."
+    exit 1
+  fi
+
+  # Top-level values.yaml — single source of truth for the bundle layout
+  # (global.bundle.<comp>.image entries enumerate everything to mirror).
+  chart_values_yaml=$(find "$chart_extract_dir" -mindepth 2 -maxdepth 2 -name 'values.yaml' -print 2>/dev/null | head -1)
+  if [[ -z "$chart_values_yaml" || ! -f "$chart_values_yaml" ]]; then
+    error "Could not locate values.yaml in chart archive."
+    exit 1
+  fi
+
+  # Bail out early on legacy/unknown bundle layouts before any registry
+  # traffic — gives the operator a clear, actionable error.
+  check_bundle_version "$chart_yaml"
+
+  # Surface the resolved env so operators can see which tagsByEnv
+  # branch the per-env images will pick up (e.g. cortex-agent).
+  local resolved_env
+  resolved_env=$(yq_or_empty '.global.metadata.env' "$values_file")
+  if [[ -n "$resolved_env" ]]; then
+    info "Resolved env from --values .global.metadata.env: $resolved_env"
+    log  "Resolved env: $resolved_env"
+  else
+    warn "No .global.metadata.env in --values; per-env images (.image.tagsByEnv)"
+    warn "will be skipped. Set 'global.metadata.env: <dev|prod|fr|gov>' to mirror them."
+  fi
+
+  local images_json image_count
+  images_json=$(build_bundle_image_list "$chart_values_yaml" "$values_file")
+
+  if [[ -z "$images_json" || "$images_json" == "[]" ]]; then
+    warn "No mirrorable images found under chart's global.bundle.*."
+    warn "Check that the chart archive is a valid konnector bundle."
+    exit 0
+  fi
+  image_count=$(jq length <<<"$images_json")
+  info "Found $image_count bundle images to pull."
+  echo ""
+
+  local pull_summary
+  # See note in init_log_file: BSD mktemp requires X's at the very end.
+  pull_summary=$(mktemp "${TMP_ROOT}/${PROGRAM_NAME}-pull-summary-XXXXXX")
+  register_temp_file "$pull_summary"
+
+  local img_entry
+  while read -r img_entry; do
+    process_pull_record "$img_entry" "$dry_run" "$pull_summary"
+  done < <(jq -c '.[]' <<<"$images_json")
+
+  info "Chart:       $chart_tgz_file"
+  info "Registry:    ${registry_host:-N/A}"
+  info "Repository:  ${image_repository:-N/A}"
+
+  local total_ok total_fail total_skip
+  print_summary_table "PULL SUMMARY" "$pull_summary" "Pulled"
+
+  # ─── 7. Push to target registry ──────────────────────────────────────
+  print_section "PUSHING TO TARGET REGISTRY"
+  info "Step 3/3: Pushing images to target registry…"
+
+  local target_host="${push_target%%/*}"
+  if [[ "$dry_run" != "true" ]]; then
+    ensure_target_registry_login "$target_host"
+  fi
+
+  local push_summary
+  push_summary=$(mktemp "${TMP_ROOT}/${PROGRAM_NAME}-push-summary-XXXXXX")
+  register_temp_file "$push_summary"
+
+  info "Pushing images to $push_target …"
+  info "Using 'docker buildx imagetools create' to preserve multi-arch manifests."
+  echo ""
+
+  if [[ -f "$pull_summary" ]]; then
+    local record
+    while IFS= read -r record; do
+      process_push_record "$record" "$push_target" "$dry_run" "$push_summary"
+    done < "$pull_summary"
+  fi
+
+  info "Source:  ${image_repository:-N/A}"
+  info "Target:  $push_target"
+
+  local push_ok push_fail push_skip
+  print_summary_table "PUSH SUMMARY" "$push_summary" "Pushed"
+  push_ok=$total_ok
+  push_fail=$total_fail
+  push_skip=$total_skip
+
+  # ─── 8. Rewrite the operator's values file in place ─────────────────
+  # In dry-run mode the values file is intentionally left untouched —
+  # the whole point of --dry-run is "preview without side effects".
+  if [[ "$dry_run" == "true" ]]; then
+    info "[DRY RUN] Skipping in-place rewrite of values file: $values_file"
+    info "[DRY RUN] Would set global.imageRegistry = $push_target"
+    if [[ -n "$docker_pull_secret_override" ]]; then
+      info "[DRY RUN] Would set global.dockerPullSecret"
+    elif [[ "$no_pull_secret" == "true" ]]; then
+      info "[DRY RUN] Would remove global.dockerPullSecret (--no-pull-secret)"
+    fi
+  else
+    info "Rewriting values file in place: $values_file"
+    rewrite_values_in_place \
+      "$values_file" "$push_target" \
+      "$docker_pull_secret_override" "$no_pull_secret"
+  fi
+
+  # ─── 9. Final help & exit code ───────────────────────────────────────
+  print_completion_summary "$chart_tgz_file" "$values_file"
+
+  log "Mirror complete. Pushed=$push_ok Failed=$push_fail Skipped=$push_skip"
+
+  # Surface push failures so CI / pipelines can react with a non-zero exit.
+  if (( push_fail > 0 )); then
+    exit 1
+  fi
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main entry — subcommand dispatcher
+# ─────────────────────────────────────────────────────────────────────────────
+# Accepted invocations:
+#   konnector                  → usage
+#   konnector help             → usage
+#   konnector -h | --help      → usage
+#   konnector version          → print version
+#   konnector -v | --version   → print version
+#   konnector mirror [flags…]  → run the mirror flow
+main() {
+  if [[ $# -eq 0 ]]; then
+    usage
+    exit 0
+  fi
+
+  local command="$1"
+  shift
+
+  # Mandatory upstream-version check. Internally short-circuits for
+  # informational commands (help/version) and respects the
+  # KCLI_SKIP_VERSION_CHECK escape hatch. Hard-fails (exit 65) when
+  # the local script is older than the canonical copy on main.
+  kcli_enforce_version "$command"
+
+  case "$command" in
+    mirror)               cmd_mirror  "$@" ;;
+    version|-v|--version) cmd_version      ;;
+    help|-h|--help)       cmd_help         ;;
+    *)
+      error "Unknown command: $command"
+      echo ""
+      usage
+      exit 64
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
Add tools/kcli/, a single-file bash CLI for operating the konnector Helm chart in private-registry / air-gapped environments. The first (and currently only) subcommand is `kcli mirror`.

What `kcli mirror` does end-to-end:

  1. Validates a konnector chart archive (--chart <chart.tgz>) and a customer Helm values file (--values <values-file>).
  2. Reads the bundle version gate from the chart's Chart.yaml (.version, with .appVersion fallback). Older bundles (major < 2) are rejected with a clear error before any registry traffic.
  3. Reads the source registry + credentials from --values (global.imageRegistry, global.dockerPullSecret) and logs in.
  4. Enumerates every mirrorable image declared by the chart under global.bundle.<comp>.image and pulls them multi-arch (per-platform, preserving the manifest list).
  5. Pushes them to --private-registry via 'docker buildx imagetools create' (with a single-arch tag+push fallback) so multi-arch indices are preserved.
  6. Rewrites the --values file IN PLACE — sets global.imageRegistry to the private registry, rewrites any per-component global.bundle.<comp>.image.repository overrides that already exist, and (per the CLI flags) sets/removes global.dockerPullSecret. A timestamped .bak is written next to the file BEFORE any mutation; --dry-run skips the rewrite entirely.

Design highlights:

  * Minimal customer values file — only global.imageRegistry + global.dockerPullSecret are required. The bundle version and the image catalog both come from --chart; operators don't have to enumerate components by hand.
  * Strict mode (set -Eeuo pipefail) + EXIT/INT/TERM traps with proper temp-file/dir registries and atomic mv-into-place rewrite, so failures never leave the values file in an inconsistent state.
  * Cross-platform bash (Linux + macOS): runtime detection of BSD vs GNU base64; pure-X mktemp templates that work on both BSD and GNU mktemp; sed -nE / find -mindepth/-maxdepth that work on both.
  * Mandatory upstream-version check on every invocation (parses the canonical VERSION constant from the script on main and refuses to run when the local copy is older — exit 65). Best-effort: skipped with a [WARN] if curl is missing, the network is unreachable, or KCLI_SKIP_VERSION_CHECK=1 is set (air-gapped).
  * TTY-aware ANSI colors honoring the NO_COLOR convention; structured audit log preserved across runs for support tickets.

Files added:

  tools/kcli/kcli                          Main bash script (~1380 LOC)
  tools/kcli/README.md                     Operator guide (Quick start,
                                           bundle compatibility, inputs,
                                           env vars, exit codes, security)
  tools/kcli/examples/values-example.yaml  Minimum --values shape
  tools/kcli/.gitignore                    Local scratch / build output
  tools/kcli/LICENSE                       Apache-2.0

Verification:

  * shellcheck --severity=style: 0 warnings
  * bash -n: syntax OK
  * End-to-end --dry-run against a real konnector-bundle-2.0.41.tgz plus customer values: bundle version detected, 5 images discovered, 4 mirrored / 1 skipped (component without a tag), values file correctly left UNTOUCHED in dry-run.
  * Cross-platform utility audit: every external command (mktemp, sed, base64, find, curl, jq, yq, tar, docker, date) used in a portable form that works on both Linux and macOS.

Exit codes:
  0    Success
  1    Runtime failure
  64   EX_USAGE — bad flags / missing required args
  65   Mandatory upstream-version check failed (local script stale)
  130  Interrupted by SIGINT/SIGTERM

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
