### PR TITLE
feat(konnector): introduce existingSecret pattern for chart secrets

### DIFF
--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.26
+version: 1.0.27
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/templates/_helpers.tpl
+++ b/charts/konnector/templates/_helpers.tpl
@@ -89,22 +89,22 @@ spec:
             - name: DISTRIBUTION_ID
               valueFrom:
                 secretKeyRef:
-                  name: distribution-id
+                  name: {{ include "secret.distributionIdName" . }}
                   key: distribution-id
             - name: HTTP_PROXY
               valueFrom:
                 secretKeyRef:
-                  name: konnector-proxy
+                  name: {{ include "secret.proxyName" . }}
                   key: httpProxy
             - name: HTTPS_PROXY
               valueFrom:
                 secretKeyRef:
-                  name: konnector-proxy
+                  name: {{ include "secret.proxyName" . }}
                   key: httpProxy
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:
-                  name: konnector-proxy
+                  name: {{ include "secret.proxyName" . }}
                   key: noProxy
           envFrom:
             - configMapRef:
@@ -145,4 +145,28 @@ Usage: {{ include "secret.valueOrExistingB64" (dict "existing" $existing "key" "
 {{- else -}}
   {{- b64enc $seed | quote -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the effective secret name for the Docker pull secret.
+If existingSecret is set, use it; otherwise use the chart-managed name.
+*/}}
+{{- define "secret.dockerSecretName" -}}
+{{- .Values.system.secrets.dockerSecret.existingSecret | default .Values.system.secrets.dockerSecret.name -}}
+{{- end -}}
+
+{{/*
+Resolve the effective secret name for the distribution-id secret.
+If existingSecret is set, use it; otherwise use the chart-managed name.
+*/}}
+{{- define "secret.distributionIdName" -}}
+{{- .Values.distribution.existingSecret | default .Values.system.secrets.distributionId.name -}}
+{{- end -}}
+
+{{/*
+Resolve the effective secret name for the proxy secret.
+If existingSecret is set, use it; otherwise use the chart-managed name.
+*/}}
+{{- define "secret.proxyName" -}}
+{{- .Values.proxyValues.existingSecret | default .Values.system.secrets.proxy.name -}}
 {{- end -}}

--- a/charts/konnector/templates/secret.yaml
+++ b/charts/konnector/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{/* Secret 1: backend-auth-secret — Runtime secret, always created by chart */}}
 {{- $ns := $.Values.namespace.name -}}
 {{- $name := $.Values.system.secrets.backendAuth.name -}}
 {{- $existing := lookup "v1" "Secret" $ns $name -}}
@@ -14,6 +15,8 @@ data:
   {{ $k }}: {{ include "secret.valueOrExistingB64" (dict "existing" $existing "key" $k "seed" "--set-by-konnnector-at-runtime--") }}
   {{- end }}
 ---
+{{/* Secret 2: docker pull secret */}}
+{{- if not .Values.system.secrets.dockerSecret.existingSecret }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
@@ -24,22 +27,28 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 data:
   .dockerconfigjson: {{ .Values.dockerPullSecret | default ( "{}" | b64enc ) }}
+{{- end }}
 ---
+{{/* Secret 3: distribution-id */}}
+{{- if not .Values.distribution.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: distribution-id
+  name: {{ .Values.system.secrets.distributionId.name }}
   namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   distribution-id: {{ .Values.distribution.id | required "The distribution.id value is required!" | quote }}
+{{- end }}
 ---
+{{/* Secret 4: konnector-proxy */}}
+{{- if not .Values.proxyValues.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: konnector-proxy
+  name: {{ .Values.system.secrets.proxy.name }}
   namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
@@ -47,3 +56,4 @@ type: Opaque
 stringData:
   httpProxy: {{ .Values.proxyValues.httpProxy | default "" | quote }}
   noProxy: {{ .Values.proxyValues.noProxy | default "" | quote }}
+{{- end }}

--- a/charts/konnector/templates/serviceaccount.yaml
+++ b/charts/konnector/templates/serviceaccount.yaml
@@ -9,4 +9,4 @@ automountServiceAccountToken: true
 secrets:
  - name: {{ .Values.system.secrets.backendAuth.name }}
 imagePullSecrets:
- - name: {{ .Values.system.secrets.dockerSecret.name }}
+ - name: {{ include "secret.dockerSecretName" . }}

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -23,6 +23,7 @@ dockerPullSecret: ""  # Secret for pulling images from a private registry
 distribution:
   id: "default-distribution-id"  # Retrieve distribution ID from Palo Alto Networks systems during installation
   url: "https://distributions.traps.paloaltonetworks.com"  # Retrieve distribution URL from Palo Alto Networks systems during installation
+  existingSecret: ""  # If set, skip creating the distribution-id secret and use this pre-existing secret name instead. The secret must contain key: distribution-id
 
 optionalValues:
   CLUSTER_URI: ""    # Cluster URI should be set when metadata service is not reachable from the cluster
@@ -33,6 +34,7 @@ optionalValues:
 proxyValues:
   httpProxy: ""  # Optional proxy URL for external network access
   noProxy: "kubernetes,kubernetes.default.svc,.svc,.cluster.local"  # List of addresses/domains that should bypass the proxy
+  existingSecret: ""  # If set, skip creating the konnector-proxy secret and use this pre-existing secret name instead. The secret must contain keys: httpProxy, noProxy
 
 priorityClassValues:
   enabled: true
@@ -237,9 +239,14 @@ system:
   # ==========================
   secrets:
     backendAuth:
-      name: backend-auth-secret  # Secret holding backend authentication credentials (e.g. API tokens)
+      name: backend-auth-secret  # Runtime secret — always created by chart, populated by konnector at runtime (e.g. API tokens). No existingSecret support.
     dockerSecret:
       name: konnector-docker-secret  # Secret for Docker credentials (e.g., for pulling private images)
+      existingSecret: ""  # If set, skip creating the docker pull secret and use this pre-existing secret name instead. The secret must be type kubernetes.io/dockerconfigjson and contain key: .dockerconfigjson
+    distributionId:
+      name: distribution-id  # Secret holding the distribution ID
+    proxy:
+      name: konnector-proxy  # Secret holding proxy configuration
 
   # ==========================
   # Apps Configurations


### PR DESCRIPTION
Add existingSecret support for 3 of 4 secrets in the konnector chart:
- distribution.existingSecret (distribution-id secret)
- proxyValues.existingSecret (konnector-proxy secret)
- system.secrets.dockerSecret.existingSecret (docker pull secret)

backend-auth-secret is excluded as it is a runtime secret populated by the konnector process.

Changes:
- values.yaml: add existingSecret fields and configurable secret names
- _helpers.tpl: add 3 secret name resolver helpers, update jobTemplate
- secret.yaml: conditional creation for 3 secrets
- serviceaccount.yaml: use resolver for imagePullSecrets

Bump chart version to 1.0.25

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
