### PR TITLE
fix(konnector): grant list/watch on CRDs for crd-manager

### DIFF
--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.27
+version: 1.0.28-rc.1
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/Chart.yaml
+++ b/charts/konnector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: konnector
 description: Deploys Palo Alto Networks' Cortex KSPM connector for advanced Kubernetes security posture management.
 type: application
-version: 1.0.28-rc.1
+version: 1.0.28
 appVersion: "1.0.0"
 maintainers:
   - name: Palo Alto Networks - Cortex KSPM team

--- a/charts/konnector/values.yaml
+++ b/charts/konnector/values.yaml
@@ -159,7 +159,7 @@ system:
       rules:
         - apiGroups: ["apiextensions.k8s.io"]
           resources: ["customresourcedefinitions"]
-          verbs: ["create", "get", "patch", "delete"]
+          verbs: ["create", "get", "list", "watch", "patch", "delete"]
     konnector-node-vm-discovery:
       rules:
         - apiGroups: [""]


### PR DESCRIPTION
## Description

Add the `list` and `watch` verbs to the `konnector-crd-manager` RBAC rule for
`customresourcedefinitions`, and bump the chart version from `1.0.27` to `1.0.28-rc.1`.

## Motivation and Context
Closes 
[CRTX-255664](https://jira-dc.paloaltonetworks.com/browse/CRTX-255664)
[XSUP-72026](https://jira-dc.paloaltonetworks.com/browse/XSUP-72026)

## How Has This Been Tested?

Fix was tested locally, details described in comment of [CRTX-255664](https://jira-dc.paloaltonetworks.com/browse/CRTX-255664)


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
